### PR TITLE
Allow root command to handle help errors and support ErrPrintHelp/ErrHelp

### DIFF
--- a/cmd/gosubc/generate.go
+++ b/cmd/gosubc/generate.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	"errors"
 	"github.com/arran4/go-subcommand"
 )
 
@@ -95,6 +96,14 @@ func (c *Generate) Execute(args []string) error {
 	}
 
 	if err := go_subcommand.Generate(c.dir, c.manDir); err != nil {
+		if errors.Is(err, go_subcommand.ErrPrintHelp) {
+			c.Usage()
+			return nil
+		}
+		if errors.Is(err, go_subcommand.ErrHelp) {
+			fmt.Fprintf(os.Stderr, "Use '%s help' for more information.\n", os.Args[0])
+			return nil
+		}
 		return fmt.Errorf("generate failed: %w", err)
 	}
 

--- a/cmd/gosubc/goreleaser.go
+++ b/cmd/gosubc/goreleaser.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"errors"
 	"github.com/arran4/go-subcommand"
 )
 
@@ -96,6 +97,14 @@ func (c *Goreleaser) Execute(args []string) error {
 	}
 
 	if err := go_subcommand.Goreleaser(c.dir, c.githubWorkflow); err != nil {
+		if errors.Is(err, go_subcommand.ErrPrintHelp) {
+			c.Usage()
+			return nil
+		}
+		if errors.Is(err, go_subcommand.ErrHelp) {
+			fmt.Fprintf(os.Stderr, "Use '%s help' for more information.\n", os.Args[0])
+			return nil
+		}
 		return fmt.Errorf("goreleaser failed: %w", err)
 	}
 

--- a/cmd/gosubc/list.go
+++ b/cmd/gosubc/list.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	"errors"
 	"github.com/arran4/go-subcommand"
 )
 
@@ -83,6 +84,14 @@ func (c *List) Execute(args []string) error {
 	}
 
 	if err := go_subcommand.List(c.dir); err != nil {
+		if errors.Is(err, go_subcommand.ErrPrintHelp) {
+			c.Usage()
+			return nil
+		}
+		if errors.Is(err, go_subcommand.ErrHelp) {
+			fmt.Fprintf(os.Stderr, "Use '%s help' for more information.\n", os.Args[0])
+			return nil
+		}
 		return fmt.Errorf("list failed: %w", err)
 	}
 

--- a/cmd/gosubc/validate.go
+++ b/cmd/gosubc/validate.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	"errors"
 	"github.com/arran4/go-subcommand"
 )
 
@@ -83,6 +84,14 @@ func (c *Validate) Execute(args []string) error {
 	}
 
 	if err := go_subcommand.Validate(c.dir); err != nil {
+		if errors.Is(err, go_subcommand.ErrPrintHelp) {
+			c.Usage()
+			return nil
+		}
+		if errors.Is(err, go_subcommand.ErrHelp) {
+			fmt.Fprintf(os.Stderr, "Use '%s help' for more information.\n", os.Args[0])
+			return nil
+		}
 		return fmt.Errorf("validate failed: %w", err)
 	}
 

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,9 @@
+package go_subcommand
+
+import "errors"
+
+// ErrPrintHelp when returned by any function anywhere it will switch the command from whatever it is to help.
+var ErrPrintHelp = errors.New("print help")
+
+// ErrHelp tells the user to use help.
+var ErrHelp = errors.New("help requested")

--- a/examples/basic1/go.mod
+++ b/examples/basic1/go.mod
@@ -1,3 +1,6 @@
 module github.com/arran4/go-subcommand/examples/basic1
 
 go 1.25.3
+
+require github.com/arran4/go-subcommand v0.0.0
+replace github.com/arran4/go-subcommand => ../..

--- a/examples/complex/go.mod
+++ b/examples/complex/go.mod
@@ -1,3 +1,6 @@
 module github.com/arran4/go-subcommand/examples/complex
 
 go 1.25.3
+
+require github.com/arran4/go-subcommand v0.0.0
+replace github.com/arran4/go-subcommand => ../..

--- a/examples/returns/go.mod
+++ b/examples/returns/go.mod
@@ -1,3 +1,6 @@
 module github.com/arran4/go-subcommand/examples/returns
 
 go 1.25.3
+
+require github.com/arran4/go-subcommand v0.0.0
+replace github.com/arran4/go-subcommand => ../..

--- a/templates/cmd.gotmpl
+++ b/templates/cmd.gotmpl
@@ -25,6 +25,10 @@ import (
 	{{- end }}
 
 	"{{.ImportPath}}"
+	{{- if and .SubCommandFunctionName .ReturnsError}}
+	"errors"
+	"github.com/arran4/go-subcommand"
+	{{- end}}
 )
 
 var _ Cmd = (*{{.SubCommandStructName}})(nil)
@@ -260,10 +264,26 @@ func (c *{{.SubCommandStructName}}) Execute(args []string) error {
 	{{if .ReturnsError}}
 	{{- if gt .ReturnCount 1 }}
 	if {{range until (add .ReturnCount -1)}}_, {{end}}err := {{if ne .SubCommandPackageName "main"}}{{.SubCommandPackageName}}.{{end}}{{.SubCommandFunctionName}}({{range $i, $p := .Parameters}}{{if $i}}, {{end}}c.{{$p.Name}}{{if $p.IsVarArg}}...{{end}}{{end}}); err != nil {
+		if errors.Is(err, go_subcommand.ErrPrintHelp) {
+			c.Usage()
+			return nil
+		}
+		if errors.Is(err, go_subcommand.ErrHelp) {
+			fmt.Fprintf(os.Stderr, "Use '%s help' for more information.\n", os.Args[0])
+			return nil
+		}
 		return fmt.Errorf("{{.SubCommandName | lower}} failed: %w", err)
 	}
 	{{- else }}
 	if err := {{if ne .SubCommandPackageName "main"}}{{.SubCommandPackageName}}.{{end}}{{.SubCommandFunctionName}}({{range $i, $p := .Parameters}}{{if $i}}, {{end}}c.{{$p.Name}}{{if $p.IsVarArg}}...{{end}}{{end}}); err != nil {
+		if errors.Is(err, go_subcommand.ErrPrintHelp) {
+			c.Usage()
+			return nil
+		}
+		if errors.Is(err, go_subcommand.ErrHelp) {
+			fmt.Fprintf(os.Stderr, "Use '%s help' for more information.\n", os.Args[0])
+			return nil
+		}
 		return fmt.Errorf("{{.SubCommandName | lower}} failed: %w", err)
 	}
 	{{- end }}

--- a/templates/root.go.gotmpl
+++ b/templates/root.go.gotmpl
@@ -29,6 +29,10 @@ import (
 	"{{.PackagePath}}/cmd/{{.MainCmdName}}/templates"
 	{{- if .FunctionName}}
 	"{{.ImportPath}}"
+	{{- if .ReturnsError}}
+	"errors"
+	"github.com/arran4/go-subcommand"
+	{{- end }}
 	{{- end }}
 )
 
@@ -298,10 +302,26 @@ func (c *RootCmd) Execute(args []string) error {
 	{{if .ReturnsError}}
 	{{- if gt .ReturnCount 1 }}
 	if {{range until (add .ReturnCount -1)}}_, {{end}}err := {{if ne .PackageName "main"}}{{.PackageName}}.{{end}}{{.FunctionName}}({{range $i, $p := .Parameters}}{{if $i}}, {{end}}c.{{$p.Name}}{{if $p.IsVarArg}}...{{end}}{{end}}); err != nil {
+		if errors.Is(err, go_subcommand.ErrPrintHelp) {
+			c.Usage()
+			return nil
+		}
+		if errors.Is(err, go_subcommand.ErrHelp) {
+			fmt.Fprintf(os.Stderr, "Use '%s help' for more information.\n", os.Args[0])
+			return nil
+		}
 		return fmt.Errorf("{{.MainCmdName | lower}} failed: %w", err)
 	}
 	{{- else }}
 	if err := {{if ne .PackageName "main"}}{{.PackageName}}.{{end}}{{.FunctionName}}({{range $i, $p := .Parameters}}{{if $i}}, {{end}}c.{{$p.Name}}{{if $p.IsVarArg}}...{{end}}{{end}}); err != nil {
+		if errors.Is(err, go_subcommand.ErrPrintHelp) {
+			c.Usage()
+			return nil
+		}
+		if errors.Is(err, go_subcommand.ErrHelp) {
+			fmt.Fprintf(os.Stderr, "Use '%s help' for more information.\n", os.Args[0])
+			return nil
+		}
 		return fmt.Errorf("{{.MainCmdName | lower}} failed: %w", err)
 	}
 	{{- end }}


### PR DESCRIPTION
Implemented `ErrPrintHelp` and `ErrHelp` handling in generated code.
- Added `errors.go` with sentinel errors.
- Updated templates to catch these errors in `Execute`.
- Updated `go.mod` in examples.
- Regenerated `gosubc` and examples.
- Verified with tests.


---
*PR created automatically by Jules for task [11685378992103903544](https://jules.google.com/task/11685378992103903544) started by @arran4*