### PR TITLE
ci: enable golangci-lint-action@v9

### DIFF
--- a/.github/workflows/generate_verification.yml
+++ b/.github/workflows/generate_verification.yml
@@ -72,15 +72,10 @@ jobs:
           go vet ./...
           cd ../..
 
-      - name: Install & Run golangci-lint
-        run: |
-          # Install golangci-lint from source to ensure compatibility with the current Go toolchain
-          go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
-
-          # Run lint on root module only
-          # Generated examples are currently skipped due to "no export data" errors
-          # caused by toolchain mismatch in the CI environment.
-          golangci-lint run
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: latest
 
       - name: Check for changes
         id: check_changes


### PR DESCRIPTION
This PR updates the `.github/workflows/generate_verification.yml` workflow to use the `golangci/golangci-lint-action@v9` instead of manually installing and running `golangci-lint`. This simplifies the workflow configuration and aligns with standard practices for Go projects using GitHub Actions. It uses `version: latest` to ensure the most up-to-date linter rules are applied. The existing `.golangci.yml` configuration which excludes `examples` and `testdata` is respected by the action.

---
*PR created automatically by Jules for task [18155019833718201892](https://jules.google.com/task/18155019833718201892) started by @arran4*