### PR TITLE
Enable golangci-lint action

### DIFF
--- a/.github/workflows/generate_verification.yml
+++ b/.github/workflows/generate_verification.yml
@@ -72,15 +72,10 @@ jobs:
           go vet ./...
           cd ../..
 
-      - name: Install & Run golangci-lint
-        run: |
-          # Install golangci-lint from source to ensure compatibility with the current Go toolchain
-          go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
-
-          # Run lint on root module only
-          # Generated examples are currently skipped due to "no export data" errors
-          # caused by toolchain mismatch in the CI environment.
-          golangci-lint run
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v9.2.0
+        with:
+          version: v1.64
 
       - name: Check for changes
         id: check_changes


### PR DESCRIPTION
Replaced manual golangci-lint installation with `golangci/golangci-lint-action@v9.2.0` in `.github/workflows/generate_verification.yml`.

---
*PR created automatically by Jules for task [16353452924773819193](https://jules.google.com/task/16353452924773819193) started by @arran4*