### PR TITLE
Add GHCR login step to GoReleaser workflow

### DIFF
--- a/templates/github/workflows/release.yml.gotmpl
+++ b/templates/github/workflows/release.yml.gotmpl
@@ -21,6 +21,12 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: stable
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ "{{" }} github.repository_owner {{ "}}" }}
+          password: ${{ "{{" }} secrets.GITHUB_TOKEN {{ "}}" }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:


### PR DESCRIPTION
Added a "Login to GHCR" step to the `release.yml.gotmpl` GitHub Actions workflow template. This step runs before the GoReleaser action and uses `docker/login-action@v3` with `github.repository_owner` and `secrets.GITHUB_TOKEN` to authenticate with `ghcr.io`. This change facilitates publishing Docker images to GHCR as part of the release process.

---
*PR created automatically by Jules for task [13238101652886840872](https://jules.google.com/task/13238101652886840872) started by @arran4*