### PR TITLE
fix: update .golangci.yml to version 2 syntax

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,10 @@
+version: "2"
+
 run:
   go: '1.25'
 
-issues:
-  exclude-dirs:
-    - examples
-    - testdata
-
+linters:
+  exclusions:
+    paths:
+      - examples
+      - testdata


### PR DESCRIPTION
This PR updates the `.golangci.yml` configuration to comply with `golangci-lint` version 2 syntax. It adds the required `version: "2"` field and migrates the deprecated `issues.exclude-dirs` setting to the new `linters.exclusions.paths` structure. This resolves the error where the linter failed to load the configuration due to a missing or unsupported version.

---
*PR created automatically by Jules for task [10888258093779822085](https://jules.google.com/task/10888258093779822085) started by @arran4*