### PR TITLE
fix(goreleaser): disable provenance to avoid manifest list error

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -55,6 +55,7 @@ dockers:
     dockerfile: Dockerfile.goreleaser
     use: buildx
     build_flag_templates:
+      - "--provenance=false"
       - "--platform=linux/amd64"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.name={{.ProjectName}}"
@@ -69,6 +70,7 @@ dockers:
     dockerfile: Dockerfile.goreleaser
     use: buildx
     build_flag_templates:
+      - "--provenance=false"
       - "--platform=linux/arm64"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.name={{.ProjectName}}"


### PR DESCRIPTION
Disable buildx provenance generation in `.goreleaser.yml` to prevent `docker manifest create` failure due to nested manifest lists.

---
*PR created automatically by Jules for task [10370350989535270195](https://jules.google.com/task/10370350989535270195) started by @arran4*