### PR TITLE
Fix invalid empty import and whitespace in generated command files (Issue #221)

### DIFF
--- a/templates/cmd/cmd.go.gotmpl
+++ b/templates/cmd/cmd.go.gotmpl
@@ -8,8 +8,10 @@ import (
 	"os"
 	"strings"
 {{- template "common_imports" (slice .Parameters true) }}
+{{- if .ImportPath}}
 
 	"{{.ImportPath}}"
+{{- end}}
 	{{- if and .SubCommandFunctionName .ReturnsError}}
 	"errors"
 	"{{.PackagePath}}/cmd"


### PR DESCRIPTION
This PR addresses Issue #221 by modifying the `cmd.go.gotmpl` template to prevent generating invalid empty imports (`""`) and extra trailing blank lines for synthetic commands (commands that exist only as parents to other commands and lack a specific implementation function).

The template now checks if `.ImportPath` is non-empty before including it in the generated import block.

A new regression test `TestIssue221_ImportFormatting` has been added to `issues_test.go` to verify:
1.  No empty import (`""`) is generated.
2.  No extra blank line (e.g., `\n\n)`) is present at the end of the import block.

Existing tests pass.

---
*PR created automatically by Jules for task [6835522432762918481](https://jules.google.com/task/6835522432762918481) started by @arran4*