### PR TITLE
Fix panic on unsupported types and add slice support

### DIFF
--- a/format_comments.go
+++ b/format_comments.go
@@ -83,7 +83,7 @@ func FormatSourceComments(dir string) error {
 					typeName := ""
 					isVarArg := false
 
-					var typeExpr ast.Expr = p.Type
+					typeExpr := p.Type
 					if ellipsis, ok := p.Type.(*ast.Ellipsis); ok {
 						isVarArg = true
 						typeExpr = ellipsis.Elt
@@ -91,9 +91,8 @@ func FormatSourceComments(dir string) error {
 
 					var err error
 					typeName, err = commentv1.FormatType(typeExpr)
-					if err != nil {
-						// Ignore error as we are just formatting comments and old behavior was ignoring unsupported types
-					}
+					// Ignore error as we are just formatting comments and old behavior was ignoring unsupported types
+					_ = err
 
 					fp := &model.FunctionParameter{
 						Name:     name.Name,

--- a/format_comments.go
+++ b/format_comments.go
@@ -82,22 +82,17 @@ func FormatSourceComments(dir string) error {
 				for _, name := range p.Names {
 					typeName := ""
 					isVarArg := false
-					switch t := p.Type.(type) {
-					case *ast.Ident:
-						typeName = t.Name
-					case *ast.SelectorExpr:
-						if ident, ok := t.X.(*ast.Ident); ok {
-							typeName = fmt.Sprintf("%s.%s", ident.Name, t.Sel.Name)
-						}
-					case *ast.Ellipsis:
+
+					var typeExpr ast.Expr = p.Type
+					if ellipsis, ok := p.Type.(*ast.Ellipsis); ok {
 						isVarArg = true
-						if ident, ok := t.Elt.(*ast.Ident); ok {
-							typeName = ident.Name
-						} else if sel, ok := t.Elt.(*ast.SelectorExpr); ok {
-							if ident, ok := sel.X.(*ast.Ident); ok {
-								typeName = fmt.Sprintf("%s.%s", ident.Name, sel.Sel.Name)
-							}
-						}
+						typeExpr = ellipsis.Elt
+					}
+
+					var err error
+					typeName, err = commentv1.FormatType(typeExpr)
+					if err != nil {
+						// Ignore error as we are just formatting comments and old behavior was ignoring unsupported types
 					}
 
 					fp := &model.FunctionParameter{

--- a/parsers/commentv1/commentv1.go
+++ b/parsers/commentv1/commentv1.go
@@ -271,7 +271,7 @@ func ParseGoFile(fset *token.FileSet, filename, importPath string, file io.Reade
 						typeName := ""
 						isVarArg := false
 
-						var typeExpr ast.Expr = p.Type
+						typeExpr := p.Type
 						if ellipsis, ok := p.Type.(*ast.Ellipsis); ok {
 							isVarArg = true
 							typeExpr = ellipsis.Elt

--- a/parsers/commentv1/issue_201_test.go
+++ b/parsers/commentv1/issue_201_test.go
@@ -1,0 +1,89 @@
+package commentv1
+
+import (
+	"go/token"
+	"strings"
+	"testing"
+)
+
+func TestParseGoFile_UnsupportedTypes(t *testing.T) {
+	src := `package main
+
+// MyCmd is a subcommand ` + "`app mycmd`" + `
+// It does things.
+func MyCmd(
+	supported string,
+	myMap map[string]int,
+) error {
+	return nil
+}
+`
+	fset := token.NewFileSet()
+	cmdTree := &CommandsTree{
+		Commands:    map[string]*CommandTree{},
+		PackagePath: "example.com/test",
+	}
+
+	// This should return an error, not panic
+	err := ParseGoFile(fset, "test.go", "example.com/test", strings.NewReader(src), cmdTree)
+	if err == nil {
+		t.Fatal("Expected error for unsupported type map[string]int, got nil")
+	}
+	expectedErr := "unsupported type: *ast.MapType"
+	if !strings.Contains(err.Error(), expectedErr) {
+		t.Errorf("Expected error containing %q, got %q", expectedErr, err.Error())
+	}
+}
+
+func TestParseGoFile_SlicesAndPointers(t *testing.T) {
+	src := `package main
+
+// MyCmd2 is a subcommand ` + "`app mycmd2`" + `
+// It does things.
+func MyCmd2(
+	mySlice []string,
+	myPtr *int,
+) error {
+	return nil
+}
+`
+	fset := token.NewFileSet()
+	cmdTree := &CommandsTree{
+		Commands:    map[string]*CommandTree{},
+		PackagePath: "example.com/test",
+	}
+
+	// This should succeed if slices and pointers are supported
+	err := ParseGoFile(fset, "test2.go", "example.com/test", strings.NewReader(src), cmdTree)
+	if err != nil {
+		t.Fatalf("Expected no error for slices and pointers, got: %v", err)
+	}
+
+	cmd := cmdTree.Commands["app"]
+	subCmd := cmd.SubCommandTree.SubCommands["mycmd2"].SubCommand
+
+	foundSlice := false
+	foundPtr := false
+
+	for _, p := range subCmd.Parameters {
+		if p.Name == "mySlice" {
+			foundSlice = true
+			if p.Type != "[]string" {
+				t.Errorf("Expected type []string, got %s", p.Type)
+			}
+		}
+		if p.Name == "myPtr" {
+			foundPtr = true
+			if p.Type != "*int" {
+				t.Errorf("Expected type *int, got %s", p.Type)
+			}
+		}
+	}
+
+	if !foundSlice {
+		t.Error("Did not find mySlice parameter")
+	}
+	if !foundPtr {
+		t.Error("Did not find myPtr parameter")
+	}
+}


### PR DESCRIPTION
- Replaced panics with error returns in `parsers/commentv1/commentv1.go`.
- Added `FormatType` function to `commentv1` package to handle recursive type formatting (pointers, slices).
- Updated `format_comments.go` to use `commentv1.FormatType` for consistent type string generation.
- Added `parsers/commentv1/issue_201_test.go` to test unsupported types and slice/pointer support.

---
*PR created automatically by Jules for task [3521832063944682532](https://jules.google.com/task/3521832063944682532) started by @arran4*