### PR TITLE
Support pointer types in flags

### DIFF
--- a/issues_test.go
+++ b/issues_test.go
@@ -868,7 +868,7 @@ func Child() {}
 
 	writer := NewMockWriter()
 	// Generate code
-	if err := GenerateWithFS(fs, writer, ".", "", "commentv1"); err != nil {
+	if err := GenerateWithFS(fs, writer, ".", "", "commentv1", nil); err != nil {
 		t.Fatalf("Generate failed: %v", err)
 	}
 

--- a/parsers/commentv1/commentv1.go
+++ b/parsers/commentv1/commentv1.go
@@ -322,6 +322,18 @@ func ParseGoFile(fset *token.FileSet, filename, importPath string, file io.Reade
 							} else {
 								panic(fmt.Sprintf("Unsupported type in array: %T", t.Elt))
 							}
+						case *ast.StarExpr:
+							if ident, ok := t.X.(*ast.Ident); ok {
+								typeName = "*" + ident.Name
+							} else if sel, ok := t.X.(*ast.SelectorExpr); ok {
+								if ident, ok := sel.X.(*ast.Ident); ok {
+									typeName = fmt.Sprintf("*%s.%s", ident.Name, sel.Sel.Name)
+								} else {
+									panic(fmt.Sprintf("Unsupported selector type in pointer: %T", sel.X))
+								}
+							} else {
+								panic(fmt.Sprintf("Unsupported type in pointer: %T", t.X))
+							}
 						default:
 							panic(fmt.Sprintf("Unsupported type: %T", t))
 						}

--- a/templates/cmd/cmd.go.gotmpl
+++ b/templates/cmd/cmd.go.gotmpl
@@ -154,6 +154,56 @@ func (c *{{.SubCommandStructName}}) Execute(args []string) error {
 					}
 				}
 				c.{{.Name}} = append(c.{{.Name}}, value)
+				{{- else if eq .Type "*string" }}
+				if !hasValue {
+					if i+1 < len(args) {
+						value = args[i+1]
+						i++
+					} else {
+						return fmt.Errorf("flag %s requires a value", name)
+					}
+				}
+				v := value
+				c.{{.Name}} = &v
+				{{- else if eq .Type "*int" }}
+				if !hasValue {
+					if i+1 < len(args) {
+						value = args[i+1]
+						i++
+					} else {
+						return fmt.Errorf("flag %s requires a value", name)
+					}
+				}
+				iv, err := strconv.Atoi(value)
+				if err != nil {
+					return fmt.Errorf("invalid integer value for flag %s: %s", name, value)
+				}
+				c.{{.Name}} = &iv
+				{{- else if eq .Type "*bool" }}
+				if hasValue {
+					b, err := strconv.ParseBool(value)
+					if err != nil {
+						return fmt.Errorf("invalid boolean value for flag %s: %s", name, value)
+					}
+					c.{{.Name}} = &b
+				} else {
+					b := true
+					c.{{.Name}} = &b
+				}
+				{{- else if eq .Type "*time.Duration" }}
+				if !hasValue {
+					if i+1 < len(args) {
+						value = args[i+1]
+						i++
+					} else {
+						return fmt.Errorf("flag %s requires a value", name)
+					}
+				}
+				d, err := time.ParseDuration(value)
+				if err != nil {
+					return fmt.Errorf("invalid duration value for flag %s: %s", name, value)
+				}
+				c.{{.Name}} = &d
 				{{- else }}
 				// TODO: Implement parsing for flag type {{.Type}}
 				{{- end }}

--- a/templates/common/common.gotmpl
+++ b/templates/common/common.gotmpl
@@ -12,6 +12,9 @@
 		{{- $hasStrconv = true }}
 		{{- end }}
 	{{- end }}
+	{{- if or (eq .Type "*int") (eq .Type "*bool") }}
+		{{- $hasStrconv = true }}
+	{{- end }}
 	{{- end }}
 	{{- if $hasStrconv }}
 	"strconv"
@@ -37,10 +40,38 @@
 			{{- else if eq .Type "bool" }}{{ $default = "false" }}
 			{{- else if eq .Type "time.Duration" }}{{ $default = "0" }}
 			{{- else if eq .Type "[]string" }}{{ $default = "nil" }}
+			{{- else if eq .Type "*string" }}{{ $default = "" }}
+			{{- else if eq .Type "*int" }}{{ $default = "" }}
+			{{- else if eq .Type "*bool" }}{{ $default = "" }}
+			{{- else if eq .Type "*time.Duration" }}{{ $default = "" }}
 			{{- else }}{{ $default = "0" }}{{ end -}}
 		{{- else -}}
 			{{- if eq .Type "string" }}{{ $default = printf "%q" .Default }}
+			{{- else if eq .Type "*string" }}{{ $default = printf "%q" .Default }}
 			{{- else }}{{ $default = .Default }}{{ end -}}
+		{{- end -}}
+
+		{{- if ne $default "" -}}
+			{{- if eq $param.Type "*string" }}
+	{
+		val := {{$default}}
+		{{$struct}}.{{$param.Name}} = &val
+	}
+			{{- else if eq $param.Type "*int" }}
+	{
+		val := {{$default}}
+		{{$struct}}.{{$param.Name}} = &val
+	}
+			{{- else if eq $param.Type "*bool" }}
+	{
+		val := {{$default}}
+		{{$struct}}.{{$param.Name}} = &val
+	}
+			{{- else if eq $param.Type "*time.Duration" }}
+	if d, err := time.ParseDuration("{{$default}}"); err == nil {
+		{{$struct}}.{{$param.Name}} = &d
+	}
+			{{- end }}
 		{{- end -}}
 
 		{{- $typeTitle := $param.Type | title -}}
@@ -56,6 +87,38 @@
 		{{$set}}.DurationVar(&{{$struct}}.{{$param.Name}}, "{{.}}", 0, "{{$desc}}")
 	}
 			{{- else if eq $param.Type "[]string" }}
+			{{- else if eq $param.Type "*string" }}
+	{{$set}}.Func("{{.}}", "{{$desc}}", func(s string) error {
+		{{$struct}}.{{$param.Name}} = &s
+		return nil
+	})
+			{{- else if eq $param.Type "*int" }}
+	{{$set}}.Func("{{.}}", "{{$desc}}", func(s string) error {
+		i, err := strconv.Atoi(s)
+		if err != nil {
+			return err
+		}
+		{{$struct}}.{{$param.Name}} = &i
+		return nil
+	})
+			{{- else if eq $param.Type "*bool" }}
+	{{$set}}.BoolFunc("{{.}}", "{{$desc}}", func(s string) error {
+		b, err := strconv.ParseBool(s)
+		if err != nil {
+			return err
+		}
+		{{$struct}}.{{$param.Name}} = &b
+		return nil
+	})
+			{{- else if eq $param.Type "*time.Duration" }}
+	{{$set}}.Func("{{.}}", "{{$desc}}", func(s string) error {
+		d, err := time.ParseDuration(s)
+		if err != nil {
+			return err
+		}
+		{{$struct}}.{{$param.Name}} = &d
+		return nil
+	})
 			{{- else }}
 	{{$set}}.{{$typeTitle}}Var(&{{$struct}}.{{$param.Name}}, "{{.}}", {{$default}}, "{{$desc}}")
 			{{- end }}
@@ -68,6 +131,38 @@
 		{{$set}}.DurationVar(&{{$struct}}.{{$param.Name}}, "{{$param.Name}}", 0, "{{$desc}}")
 	}
 		{{- else if eq $param.Type "[]string" }}
+		{{- else if eq $param.Type "*string" }}
+	{{$set}}.Func("{{$param.Name}}", "{{$desc}}", func(s string) error {
+		{{$struct}}.{{$param.Name}} = &s
+		return nil
+	})
+		{{- else if eq $param.Type "*int" }}
+	{{$set}}.Func("{{$param.Name}}", "{{$desc}}", func(s string) error {
+		i, err := strconv.Atoi(s)
+		if err != nil {
+			return err
+		}
+		{{$struct}}.{{$param.Name}} = &i
+		return nil
+	})
+		{{- else if eq $param.Type "*bool" }}
+	{{$set}}.BoolFunc("{{$param.Name}}", "{{$desc}}", func(s string) error {
+		b, err := strconv.ParseBool(s)
+		if err != nil {
+			return err
+		}
+		{{$struct}}.{{$param.Name}} = &b
+		return nil
+	})
+		{{- else if eq $param.Type "*time.Duration" }}
+	{{$set}}.Func("{{$param.Name}}", "{{$desc}}", func(s string) error {
+		d, err := time.ParseDuration(s)
+		if err != nil {
+			return err
+		}
+		{{$struct}}.{{$param.Name}} = &d
+		return nil
+	})
 		{{- else }}
 	{{$set}}.{{$typeTitle}}Var(&{{$struct}}.{{$param.Name}}, "{{$param.Name}}", {{$default}}, "{{$desc}}")
 		{{- end }}

--- a/templates/common/common.gotmpl
+++ b/templates/common/common.gotmpl
@@ -40,10 +40,10 @@
 			{{- else if eq .Type "bool" }}{{ $default = "false" }}
 			{{- else if eq .Type "time.Duration" }}{{ $default = "0" }}
 			{{- else if eq .Type "[]string" }}{{ $default = "nil" }}
-			{{- else if eq .Type "*string" }}{{ $default = "" }}
-			{{- else if eq .Type "*int" }}{{ $default = "" }}
-			{{- else if eq .Type "*bool" }}{{ $default = "" }}
-			{{- else if eq .Type "*time.Duration" }}{{ $default = "" }}
+			{{- else if eq .Type "*string" }}{{ $default = "nil" }}
+			{{- else if eq .Type "*int" }}{{ $default = "nil" }}
+			{{- else if eq .Type "*bool" }}{{ $default = "nil" }}
+			{{- else if eq .Type "*time.Duration" }}{{ $default = "nil" }}
 			{{- else }}{{ $default = "0" }}{{ end -}}
 		{{- else -}}
 			{{- if eq .Type "string" }}{{ $default = printf "%q" .Default }}
@@ -51,7 +51,7 @@
 			{{- else }}{{ $default = .Default }}{{ end -}}
 		{{- end -}}
 
-		{{- if ne $default "" -}}
+		{{- if and (ne $default "") (ne $default "nil") -}}
 			{{- if eq $param.Type "*string" }}
 	{
 		val := {{$default}}


### PR DESCRIPTION
Support pointer types (*string, *int, *bool, *time.Duration) in flags to allow optional arguments where nil indicates absence. Updates parser and templates.

---
*PR created automatically by Jules for task [16749831145422199039](https://jules.google.com/task/16749831145422199039) started by @arran4*