### PR TITLE
Align usage text flag, default, and description columns

### DIFF
--- a/issues_test.go
+++ b/issues_test.go
@@ -868,7 +868,7 @@ func Child() {}
 
 	writer := NewMockWriter()
 	// Generate code
-	if err := GenerateWithFS(fs, writer, ".", "", "commentv1"); err != nil {
+	if err := GenerateWithFS(fs, writer, ".", "", "commentv1", nil); err != nil {
 		t.Fatalf("Generate failed: %v", err)
 	}
 

--- a/model/model.go
+++ b/model/model.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"fmt"
 	"go/token"
 	"strings"
 )
@@ -68,6 +69,17 @@ func (p *FunctionParameter) FlagString() string {
 	return flags + typeStr
 }
 
+func (p *FunctionParameter) DefaultString() string {
+	if p.Default == "" {
+		return ""
+	}
+	def := p.Default
+	if p.Type == "string" && !strings.HasPrefix(def, "\"") {
+		def = fmt.Sprintf("%q", def)
+	}
+	return fmt.Sprintf("(default: %s)", def)
+}
+
 type SubCommand struct {
 	*Command
 	Parent                 *SubCommand
@@ -114,6 +126,20 @@ func (sc *SubCommand) MaxFlagLength() int {
 	max := 0
 	for _, p := range sc.Parameters {
 		l := len(p.FlagString())
+		if l > max {
+			max = l
+		}
+	}
+	return max
+}
+
+func (sc *SubCommand) MaxDefaultLength() int {
+	max := 0
+	for _, p := range sc.Parameters {
+		if p.IsPositional {
+			continue
+		}
+		l := len(p.DefaultString())
 		if l > max {
 			max = l
 		}

--- a/templates/cmd/templates/usage.txt.gotmpl
+++ b/templates/cmd/templates/usage.txt.gotmpl
@@ -29,10 +29,10 @@ Subcommands:
     usage        Print this usage message
 {{- end}}
 {{end}}{{/* End Subcommands block */}}{{$hasFlags := false}}{{range .Parameters}}{{if not .IsPositional}}{{$hasFlags = true}}{{end}}{{end}}{{if $hasFlags}}
-Flags:{{$max := add .MaxFlagLength 2 -}}
+Flags:{{$maxFlag := add .MaxFlagLength 2}}{{$maxDef := .MaxDefaultLength}}{{if gt $maxDef 0}}{{$maxDef = add $maxDef 2}}{{end}}
 {{- range .Parameters}}
 {{- if not .IsPositional -}}
-{{printf "\n    %-*s %s" $max .FlagString .Description}}{{if .Default}} (default: {{.Default}}){{end}}
+{{printf "\n    %-*s %-*s %s" $maxFlag .FlagString $maxDef .DefaultString .Description}}
 {{- end}}
 {{- end}}
 {{end}}{{$hasPositional := false}}{{range .Parameters}}{{if .IsPositional}}{{$hasPositional = true}}{{end}}{{end}}{{if $hasPositional}}

--- a/templates/testdata/alignment_long.txtar
+++ b/templates/testdata/alignment_long.txtar
@@ -53,6 +53,6 @@ Subcommands:
 {{end}}
 
 Flags:
-    -s              Short flag (default: false)
-    --long string   This is a very long flag description to see how it wraps or aligns in the output when the flag name itself is quite long.
-    --another int   Another flag (default: 42)
+    -s              (default: false)   Short flag
+    --long string                      This is a very long flag description to see how it wraps or aligns in the output when the flag name itself is quite long.
+    --another int   (default: 42)      Another flag

--- a/templates/testdata/complex_flags.txtar
+++ b/templates/testdata/complex_flags.txtar
@@ -34,7 +34,7 @@
 Usage: flagsapp test [flags...]
 
 Flags:
-    --simple string       Simple string flag
-    -m, --mu, --multi     Flag with multiple aliases (default: true)
-    --no-alias int        Flag without aliases (default: 10)
-    --duration duration   Duration flag (default: 1s)
+    --simple string                         Simple string flag
+    -m, --mu, --multi     (default: true)   Flag with multiple aliases
+    --no-alias int        (default: 10)     Flag without aliases
+    --duration duration   (default: 1s)     Duration flag

--- a/templates/testdata/functional.txtar
+++ b/templates/testdata/functional.txtar
@@ -76,5 +76,5 @@ Subcommands:
     usage        Print this usage message
 
 Flags:
-    -v       Enable verbose (default: false)
-    -c int   Count items (default: 0)
+    -v       (default: false)   Enable verbose
+    -c int   (default: 0)       Count items

--- a/templates/testdata/issue50_subcommand_usage.txtar
+++ b/templates/testdata/issue50_subcommand_usage.txtar
@@ -25,4 +25,4 @@ Subcommands:
     usage        Print this usage message
 
 Flags:
-    -f   Force execution
+    -f    Force execution

--- a/templates/testdata/usage.txtar
+++ b/templates/testdata/usage.txtar
@@ -74,5 +74,5 @@ Subcommands:
 {{end}}
 
 Flags:
-    -v       Enable verbose (default: false)
-    -c int   Count items (default: 0)
+    -v       (default: false)   Enable verbose
+    -c int   (default: 0)       Count items

--- a/templates/testdata/usage_no_sub.txtar
+++ b/templates/testdata/usage_no_sub.txtar
@@ -29,7 +29,7 @@ Subcommands:
     usage        Print this usage message
 
 Flags:
-    -f              Force action (default: false)
+    -f              (default: false)   Force action
 
 Positional Arguments:
     file       Target file


### PR DESCRIPTION
Implemented aligned column output for usage text generation. Default values now appear in a dedicated column between flags and descriptions, improving readability. This involved updating the usage template and adding helper methods to the data model. Also fixed a test failure in `issues_test.go`.

---
*PR created automatically by Jules for task [195553688910127049](https://jules.google.com/task/195553688910127049) started by @arran4*