### PR TITLE
Fix subcommand name conflict and file overwrite

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -145,10 +145,11 @@ func assignUsageFileNames(subCommands []*model.SubCommand) {
 	}
 }
 func generateSubCommandFiles(writer FileWriter, cmdOutDir, cmdTemplatesDir, manDir string, subCmd *model.SubCommand) error {
-	if err := generateFile(writer, cmdOutDir, subCmd.SubCommandName+".go", "cmd.go.gotmpl", subCmd, true); err != nil {
+	fileName := strings.ReplaceAll(parsers.ToKebabCase(subCmd.SubCommandStructName), "-", "_")
+	if err := generateFile(writer, cmdOutDir, fileName+".go", "cmd.go.gotmpl", subCmd, true); err != nil {
 		return err
 	}
-	if err := generateFile(writer, cmdOutDir, subCmd.SubCommandName+"_test.go", "cmd_test.go.gotmpl", subCmd, true); err != nil {
+	if err := generateFile(writer, cmdOutDir, fileName+"_test.go", "cmd_test.go.gotmpl", subCmd, true); err != nil {
 		return err
 	}
 	if err := generateFile(writer, cmdTemplatesDir, subCmd.UsageFileName, "usage.txt.gotmpl", subCmd, false); err != nil {

--- a/parsers/commentv1/commentv1.go
+++ b/parsers/commentv1/commentv1.go
@@ -224,7 +224,11 @@ func collectSubCommands(cmd *model.Command, name string, sct *SubCommandTree, pa
 		sct.Command = cmd
 		sct.Parent = parent
 		// Allocate unique struct name
-		sct.SubCommandStructName = allocator.Allocate(sct.SubCommandName)
+		allocateName := sct.SubCommandName
+		if parent != nil {
+			allocateName = parent.SubCommandStructName + " " + allocateName
+		}
+		sct.SubCommandStructName = allocator.Allocate(allocateName)
 
 		subCommands = append(subCommands, sct.SubCommand)
 		for _, name := range subCommandNames {
@@ -239,11 +243,15 @@ func collectSubCommands(cmd *model.Command, name string, sct *SubCommandTree, pa
 			}
 		} else {
 			// Missing intermediate node -> Synthetic command
+			allocateName := name
+			if parent != nil {
+				allocateName = parent.SubCommandStructName + " " + allocateName
+			}
 			syntheticCmd := &model.SubCommand{
 				Command:                cmd,
 				Parent:                 parent,
 				SubCommandName:         name,
-				SubCommandStructName:   allocator.Allocate(name),
+				SubCommandStructName:   allocator.Allocate(allocateName),
 				SubCommandFunctionName: "", // Empty to indicate synthetic
 			}
 			subCommands = append(subCommands, syntheticCmd)


### PR DESCRIPTION
Resolves issue #251 where nested subcommands with the same name caused struct name conflicts and file overwrites.

Changes:
- `parsers/commentv1/commentv1.go`: Prefix subcommand struct names with parent struct name.
- `generate.go`: Use snake_case of struct name for generated filenames.
- `issues_test.go`: Added regression test.

---
*PR created automatically by Jules for task [6586301442252113259](https://jules.google.com/task/6586301442252113259) started by @arran4*