### PR TITLE
Update verification workflow to auto-close obsolete PRs

### DIFF
--- a/.github/workflows/generate_verification.yml
+++ b/.github/workflows/generate_verification.yml
@@ -92,7 +92,6 @@ jobs:
 
       - name: Determine PR attributes
         id: pr_attributes
-        if: steps.check_changes.outputs.changes_detected == 'true'
         env:
           HEAD_REF: ${{ github.head_ref }}
           REF_NAME: ${{ github.ref_name }}
@@ -107,7 +106,6 @@ jobs:
           fi
 
       - name: Create Pull Request
-        if: steps.check_changes.outputs.changes_detected == 'true'
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The `generate_verification.yml` workflow was previously configured to skip the Pull Request creation step if no changes were detected in the generated code. However, this prevented the workflow from automatically cleaning up existing PRs when the underlying issue was resolved (e.g., by merging a fix to the main branch).

By removing the conditional check, the `create-pull-request` action now runs unconditionally. The action's built-in `delete-branch: true` logic handles the cleanup: if the branch exists but there are no changes to commit, it deletes the branch, which automatically closes the associated PR.


---
*PR created automatically by Jules for task [9764430551909793356](https://jules.google.com/task/9764430551909793356) started by @arran4*