### PR TITLE
Add environment variable support for flags

### DIFF
--- a/cmd/gosubc/format-source-comments.go
+++ b/cmd/gosubc/format-source-comments.go
@@ -129,9 +129,11 @@ func (c *RootCmd) NewFormatSourceComments() *FormatSourceComments {
 		SubCommands: make(map[string]Cmd),
 	}
 
-	set.StringVar(&v.dir, "dir", ".", "The project root directory containing go.mod")
+	dirDefault := "."
+	set.StringVar(&v.dir, "dir", dirDefault, "The project root directory containing go.mod")
 
-	set.BoolVar(&v.recursive, "recursive", true, "Search recursively")
+	recursiveDefault := true
+	set.BoolVar(&v.recursive, "recursive", recursiveDefault, "Search recursively")
 	set.Usage = v.Usage
 
 	v.CommandAction = func(c *FormatSourceComments) error {

--- a/cmd/gosubc/format-source-comments_test.go
+++ b/cmd/gosubc/format-source-comments_test.go
@@ -24,6 +24,8 @@ func TestFormatSourceComments_Execute(t *testing.T) {
 	args := []string{}
 	args = append(args, "--dir")
 	args = append(args, "test")
+	args = append(args, "--paths")
+	args = append(args, "--recursive")
 
 	err := cmd.Execute(args)
 	if err != nil {
@@ -35,5 +37,8 @@ func TestFormatSourceComments_Execute(t *testing.T) {
 
 	if cmd.dir != "test" {
 		t.Errorf("Expected dir to be 'test', got '%v'", cmd.dir)
+	}
+	if cmd.recursive != true {
+		t.Errorf("Expected recursive to be true, got '%v'", cmd.recursive)
 	}
 }

--- a/cmd/gosubc/format.go
+++ b/cmd/gosubc/format.go
@@ -141,11 +141,14 @@ func (c *RootCmd) NewFormat() *Format {
 		SubCommands: make(map[string]Cmd),
 	}
 
-	set.StringVar(&v.dir, "dir", ".", "The project root directory")
+	dirDefault := "."
+	set.StringVar(&v.dir, "dir", dirDefault, "The project root directory")
 
-	set.BoolVar(&v.inplace, "inplace", false, "Modify files in place")
+	inplaceDefault := false
+	set.BoolVar(&v.inplace, "inplace", inplaceDefault, "Modify files in place")
 
-	set.BoolVar(&v.recursive, "recursive", true, "Search recursively")
+	recursiveDefault := true
+	set.BoolVar(&v.recursive, "recursive", recursiveDefault, "Search recursively")
 	set.Usage = v.Usage
 
 	v.CommandAction = func(c *Format) error {

--- a/cmd/gosubc/format_test.go
+++ b/cmd/gosubc/format_test.go
@@ -25,6 +25,8 @@ func TestFormat_Execute(t *testing.T) {
 	args = append(args, "--dir")
 	args = append(args, "test")
 	args = append(args, "--inplace")
+	args = append(args, "--paths")
+	args = append(args, "--recursive")
 
 	err := cmd.Execute(args)
 	if err != nil {
@@ -39,5 +41,8 @@ func TestFormat_Execute(t *testing.T) {
 	}
 	if cmd.inplace != true {
 		t.Errorf("Expected inplace to be true, got '%v'", cmd.inplace)
+	}
+	if cmd.recursive != true {
+		t.Errorf("Expected recursive to be true, got '%v'", cmd.recursive)
 	}
 }

--- a/cmd/gosubc/generate.go
+++ b/cmd/gosubc/generate.go
@@ -153,13 +153,17 @@ func (c *RootCmd) NewGenerate() *Generate {
 		SubCommands: make(map[string]Cmd),
 	}
 
-	set.StringVar(&v.dir, "dir", ".", "Project root directory containing go.mod")
+	dirDefault := "."
+	set.StringVar(&v.dir, "dir", dirDefault, "Project root directory containing go.mod")
 
-	set.StringVar(&v.manDir, "man-dir", "", "Directory to generate man pages in optional")
+	manDirDefault := ""
+	set.StringVar(&v.manDir, "man-dir", manDirDefault, "Directory to generate man pages in optional")
 
-	set.StringVar(&v.parserName, "parser-name", "commentv1", "Name of the parser to use")
+	parserNameDefault := "commentv1"
+	set.StringVar(&v.parserName, "parser-name", parserNameDefault, "Name of the parser to use")
 
-	set.BoolVar(&v.recursive, "recursive", true, "Search recursively")
+	recursiveDefault := true
+	set.BoolVar(&v.recursive, "recursive", recursiveDefault, "Search recursively")
 	set.Usage = v.Usage
 
 	v.CommandAction = func(c *Generate) error {

--- a/cmd/gosubc/generate_test.go
+++ b/cmd/gosubc/generate_test.go
@@ -28,6 +28,8 @@ func TestGenerate_Execute(t *testing.T) {
 	args = append(args, "test")
 	args = append(args, "--parserName")
 	args = append(args, "test")
+	args = append(args, "--paths")
+	args = append(args, "--recursive")
 
 	err := cmd.Execute(args)
 	if err != nil {
@@ -45,5 +47,8 @@ func TestGenerate_Execute(t *testing.T) {
 	}
 	if cmd.parserName != "test" {
 		t.Errorf("Expected parserName to be 'test', got '%v'", cmd.parserName)
+	}
+	if cmd.recursive != true {
+		t.Errorf("Expected recursive to be true, got '%v'", cmd.recursive)
 	}
 }

--- a/cmd/gosubc/goreleaser.go
+++ b/cmd/gosubc/goreleaser.go
@@ -129,11 +129,14 @@ func (c *RootCmd) NewGoreleaser() *Goreleaser {
 		SubCommands: make(map[string]Cmd),
 	}
 
-	set.StringVar(&v.dir, "dir", ".", "TODO: Add usage text")
+	dirDefault := "."
+	set.StringVar(&v.dir, "dir", dirDefault, "TODO: Add usage text")
 
-	set.BoolVar(&v.githubWorkflow, "go-releaser-github-workflow", false, "Generate GitHub Actions release workflow")
+	githubWorkflowDefault := false
+	set.BoolVar(&v.githubWorkflow, "go-releaser-github-workflow", githubWorkflowDefault, "Generate GitHub Actions release workflow")
 
-	set.BoolVar(&v.verificationWorkflow, "verification-workflow", false, "Generate verification workflow")
+	verificationWorkflowDefault := false
+	set.BoolVar(&v.verificationWorkflow, "verification-workflow", verificationWorkflowDefault, "Generate verification workflow")
 	set.Usage = v.Usage
 
 	v.CommandAction = func(c *Goreleaser) error {

--- a/cmd/gosubc/list.go
+++ b/cmd/gosubc/list.go
@@ -141,11 +141,14 @@ func (c *RootCmd) NewList() *List {
 		SubCommands: make(map[string]Cmd),
 	}
 
-	set.StringVar(&v.dir, "dir", ".", "The project root directory containing go.mod")
+	dirDefault := "."
+	set.StringVar(&v.dir, "dir", dirDefault, "The project root directory containing go.mod")
 
-	set.StringVar(&v.parserName, "parser-name", "commentv1", "Name of the parser to use")
+	parserNameDefault := "commentv1"
+	set.StringVar(&v.parserName, "parser-name", parserNameDefault, "Name of the parser to use")
 
-	set.BoolVar(&v.recursive, "recursive", true, "Search recursively")
+	recursiveDefault := true
+	set.BoolVar(&v.recursive, "recursive", recursiveDefault, "Search recursively")
 	set.Usage = v.Usage
 
 	v.CommandAction = func(c *List) error {

--- a/cmd/gosubc/list_test.go
+++ b/cmd/gosubc/list_test.go
@@ -26,6 +26,8 @@ func TestList_Execute(t *testing.T) {
 	args = append(args, "test")
 	args = append(args, "--parserName")
 	args = append(args, "test")
+	args = append(args, "--paths")
+	args = append(args, "--recursive")
 
 	err := cmd.Execute(args)
 	if err != nil {
@@ -40,5 +42,8 @@ func TestList_Execute(t *testing.T) {
 	}
 	if cmd.parserName != "test" {
 		t.Errorf("Expected parserName to be 'test', got '%v'", cmd.parserName)
+	}
+	if cmd.recursive != true {
+		t.Errorf("Expected recursive to be true, got '%v'", cmd.recursive)
 	}
 }

--- a/cmd/gosubc/scan.go
+++ b/cmd/gosubc/scan.go
@@ -141,11 +141,14 @@ func (c *RootCmd) NewScan() *Scan {
 		SubCommands: make(map[string]Cmd),
 	}
 
-	set.StringVar(&v.dir, "dir", ".", "The project root directory")
+	dirDefault := "."
+	set.StringVar(&v.dir, "dir", dirDefault, "The project root directory")
 
-	set.StringVar(&v.parserName, "parser-name", "commentv1", "Name of the parser to use")
+	parserNameDefault := "commentv1"
+	set.StringVar(&v.parserName, "parser-name", parserNameDefault, "Name of the parser to use")
 
-	set.BoolVar(&v.recursive, "recursive", true, "Search recursively")
+	recursiveDefault := true
+	set.BoolVar(&v.recursive, "recursive", recursiveDefault, "Search recursively")
 	set.Usage = v.Usage
 
 	v.CommandAction = func(c *Scan) error {

--- a/cmd/gosubc/scan_test.go
+++ b/cmd/gosubc/scan_test.go
@@ -24,6 +24,10 @@ func TestScan_Execute(t *testing.T) {
 	args := []string{}
 	args = append(args, "--dir")
 	args = append(args, "test")
+	args = append(args, "--parserName")
+	args = append(args, "test")
+	args = append(args, "--paths")
+	args = append(args, "--recursive")
 
 	err := cmd.Execute(args)
 	if err != nil {
@@ -35,5 +39,11 @@ func TestScan_Execute(t *testing.T) {
 
 	if cmd.dir != "test" {
 		t.Errorf("Expected dir to be 'test', got '%v'", cmd.dir)
+	}
+	if cmd.parserName != "test" {
+		t.Errorf("Expected parserName to be 'test', got '%v'", cmd.parserName)
+	}
+	if cmd.recursive != true {
+		t.Errorf("Expected recursive to be true, got '%v'", cmd.recursive)
 	}
 }

--- a/cmd/gosubc/templates/format-source-comments_usage.txt
+++ b/cmd/gosubc/templates/format-source-comments_usage.txt
@@ -8,6 +8,6 @@ Subcommands:
     usage        Print this usage message
 
 Flags:
-    --dir string      The project root directory containing go.mod (default: .)
-    --path []string   Paths to search for subcommands relative to dir (default: nil)
-    --recursive       Search recursively (default: true)
+    --dir string      (default: ".")    The project root directory containing go.mod
+    --path []string   (default: nil)    Paths to search for subcommands relative to dir
+    --recursive       (default: true)   Search recursively

--- a/cmd/gosubc/templates/format_usage.txt
+++ b/cmd/gosubc/templates/format_usage.txt
@@ -11,7 +11,7 @@ Subcommands:
     usage        Print this usage message
 
 Flags:
-    --dir string      The project root directory (default: .)
-    --inplace         Modify files in place
-    --path []string   Paths to search for subcommands relative to dir (default: nil)
-    --recursive       Search recursively (default: true)
+    --dir string      (default: ".")    The project root directory
+    --inplace                           Modify files in place
+    --path []string   (default: nil)    Paths to search for subcommands relative to dir
+    --recursive       (default: true)   Search recursively

--- a/cmd/gosubc/templates/generate_usage.txt
+++ b/cmd/gosubc/templates/generate_usage.txt
@@ -8,8 +8,8 @@ Subcommands:
     usage        Print this usage message
 
 Flags:
-    --dir string           Project root directory containing go.mod (default: .)
-    --man-dir string       Directory to generate man pages in optional
-    --parser-name string   Name of the parser to use (default: commentv1)
-    --path []string        Paths to search for subcommands relative to dir (default: nil)
-    --recursive            Search recursively (default: true)
+    --dir string           (default: ".")           Project root directory containing go.mod
+    --man-dir string                                Directory to generate man pages in optional
+    --parser-name string   (default: "commentv1")   Name of the parser to use
+    --path []string        (default: nil)           Paths to search for subcommands relative to dir
+    --recursive            (default: true)          Search recursively

--- a/cmd/gosubc/templates/goreleaser_usage.txt
+++ b/cmd/gosubc/templates/goreleaser_usage.txt
@@ -6,6 +6,6 @@ Subcommands:
     usage        Print this usage message
 
 Flags:
-    --dir string                     (default: .)
-    --go-releaser-github-workflow   Generate GitHub Actions release workflow (default: false)
-    --verification-workflow         Generate verification workflow (default: false)
+    --dir string                    (default: ".")
+    --go-releaser-github-workflow   (default: false)   Generate GitHub Actions release workflow
+    --verification-workflow         (default: false)   Generate verification workflow

--- a/cmd/gosubc/templates/list_usage.txt
+++ b/cmd/gosubc/templates/list_usage.txt
@@ -8,7 +8,7 @@ Subcommands:
     usage        Print this usage message
 
 Flags:
-    --dir string           The project root directory containing go.mod (default: .)
-    --parser-name string   Name of the parser to use (default: commentv1)
-    --path []string        Paths to search for subcommands relative to dir (default: nil)
-    --recursive            Search recursively (default: true)
+    --dir string           (default: ".")           The project root directory containing go.mod
+    --parser-name string   (default: "commentv1")   Name of the parser to use
+    --path []string        (default: nil)           Paths to search for subcommands relative to dir
+    --recursive            (default: true)          Search recursively

--- a/cmd/gosubc/templates/scan_usage.txt
+++ b/cmd/gosubc/templates/scan_usage.txt
@@ -11,7 +11,7 @@ Subcommands:
     usage        Print this usage message
 
 Flags:
-    --dir string           The project root directory (default: .)
-    --parser-name string   Name of the parser to use (default: commentv1)
-    --path []string        Paths to search for subcommands relative to dir (default: nil)
-    --recursive            Search recursively (default: true)
+    --dir string           (default: ".")           The project root directory
+    --parser-name string   (default: "commentv1")   Name of the parser to use
+    --path []string        (default: nil)           Paths to search for subcommands relative to dir
+    --recursive            (default: true)          Search recursively

--- a/cmd/gosubc/templates/validate_usage.txt
+++ b/cmd/gosubc/templates/validate_usage.txt
@@ -8,7 +8,7 @@ Subcommands:
     usage        Print this usage message
 
 Flags:
-    --dir string           The project root directory containing go.mod (default: .)
-    --parser-name string   Name of the parser to use (default: commentv1)
-    --path []string        Paths to search for subcommands relative to dir (default: nil)
-    --recursive            Search recursively (default: true)
+    --dir string           (default: ".")           The project root directory containing go.mod
+    --parser-name string   (default: "commentv1")   Name of the parser to use
+    --path []string        (default: nil)           Paths to search for subcommands relative to dir
+    --recursive            (default: true)          Search recursively

--- a/cmd/gosubc/validate.go
+++ b/cmd/gosubc/validate.go
@@ -141,11 +141,14 @@ func (c *RootCmd) NewValidate() *Validate {
 		SubCommands: make(map[string]Cmd),
 	}
 
-	set.StringVar(&v.dir, "dir", ".", "The project root directory containing go.mod")
+	dirDefault := "."
+	set.StringVar(&v.dir, "dir", dirDefault, "The project root directory containing go.mod")
 
-	set.StringVar(&v.parserName, "parser-name", "commentv1", "Name of the parser to use")
+	parserNameDefault := "commentv1"
+	set.StringVar(&v.parserName, "parser-name", parserNameDefault, "Name of the parser to use")
 
-	set.BoolVar(&v.recursive, "recursive", true, "Search recursively")
+	recursiveDefault := true
+	set.BoolVar(&v.recursive, "recursive", recursiveDefault, "Search recursively")
 	set.Usage = v.Usage
 
 	v.CommandAction = func(c *Validate) error {

--- a/cmd/gosubc/validate_test.go
+++ b/cmd/gosubc/validate_test.go
@@ -26,6 +26,8 @@ func TestValidate_Execute(t *testing.T) {
 	args = append(args, "test")
 	args = append(args, "--parserName")
 	args = append(args, "test")
+	args = append(args, "--paths")
+	args = append(args, "--recursive")
 
 	err := cmd.Execute(args)
 	if err != nil {
@@ -40,5 +42,8 @@ func TestValidate_Execute(t *testing.T) {
 	}
 	if cmd.parserName != "test" {
 		t.Errorf("Expected parserName to be 'test', got '%v'", cmd.parserName)
+	}
+	if cmd.recursive != true {
+		t.Errorf("Expected recursive to be true, got '%v'", cmd.recursive)
 	}
 }

--- a/model/model.go
+++ b/model/model.go
@@ -34,6 +34,7 @@ type FunctionParameter struct {
 	Name               string
 	Type               string
 	FlagAliases        []string
+	EnvVars            []string
 	Default            string
 	Description        string
 	IsPositional       bool

--- a/templates/common/common.gotmpl
+++ b/templates/common/common.gotmpl
@@ -8,7 +8,7 @@
 	{{- $hasDuration = true }}
 	{{- end }}
 	{{- if or (eq .Type "int") (eq .Type "bool") }}
-		{{- if or .IsPositional $needStrconvForFlags }}
+		{{- if or .IsPositional $needStrconvForFlags .EnvVars }}
 		{{- $hasStrconv = true }}
 		{{- end }}
 	{{- end }}
@@ -47,29 +47,58 @@
 		{{- if eq $param.Type "time.Duration" -}}
 			{{- $typeTitle = "Duration" -}}
 		{{- end -}}
+
+		{{- $defaultVar := printf "%sDefault" $param.Name -}}
+
+		{{- if eq $param.Type "time.Duration" }}
+	var {{$defaultVar}} time.Duration
+	if d, err := time.ParseDuration("{{$param.Default}}"); err == nil {
+		{{$defaultVar}} = d
+	} else {
+		{{$defaultVar}} = 0
+	}
+		{{- else if eq $param.Type "[]string" }}
+		{{- else }}
+	{{$defaultVar}} := {{$default}}
+		{{- end }}
+
+		{{- if .EnvVars }}
+		{{- range .EnvVars }}
+	if v := os.Getenv("{{.}}"); v != "" {
+			{{- if eq $param.Type "string" }}
+		{{$defaultVar}} = v
+			{{- else if eq $param.Type "int" }}
+		if i, err := strconv.Atoi(v); err == nil {
+			{{$defaultVar}} = i
+		}
+			{{- else if eq $param.Type "bool" }}
+		if b, err := strconv.ParseBool(v); err == nil {
+			{{$defaultVar}} = b
+		}
+			{{- else if eq $param.Type "time.Duration" }}
+		if d, err := time.ParseDuration(v); err == nil {
+			{{$defaultVar}} = d
+		}
+			{{- end }}
+	}
+		{{- end }}
+		{{- end }}
+
 		{{- if .FlagAliases -}}
 			{{- range .FlagAliases }}
 			{{- if eq $param.Type "time.Duration" }}
-	if d, err := time.ParseDuration("{{$default}}"); err == nil {
-		{{$set}}.DurationVar(&{{$struct}}.{{$param.Name}}, "{{.}}", d, "{{$desc}}")
-	} else {
-		{{$set}}.DurationVar(&{{$struct}}.{{$param.Name}}, "{{.}}", 0, "{{$desc}}")
-	}
+	{{$set}}.DurationVar(&{{$struct}}.{{$param.Name}}, "{{.}}", {{$defaultVar}}, "{{$desc}}")
 			{{- else if eq $param.Type "[]string" }}
 			{{- else }}
-	{{$set}}.{{$typeTitle}}Var(&{{$struct}}.{{$param.Name}}, "{{.}}", {{$default}}, "{{$desc}}")
+	{{$set}}.{{$typeTitle}}Var(&{{$struct}}.{{$param.Name}}, "{{.}}", {{$defaultVar}}, "{{$desc}}")
 			{{- end }}
 			{{- end -}}
 		{{- else -}}
 		{{- if eq $param.Type "time.Duration" }}
-	if d, err := time.ParseDuration("{{$default}}"); err == nil {
-		{{$set}}.DurationVar(&{{$struct}}.{{$param.Name}}, "{{$param.Name}}", d, "{{$desc}}")
-	} else {
-		{{$set}}.DurationVar(&{{$struct}}.{{$param.Name}}, "{{$param.Name}}", 0, "{{$desc}}")
-	}
+	{{$set}}.DurationVar(&{{$struct}}.{{$param.Name}}, "{{$param.Name}}", {{$defaultVar}}, "{{$desc}}")
 		{{- else if eq $param.Type "[]string" }}
 		{{- else }}
-	{{$set}}.{{$typeTitle}}Var(&{{$struct}}.{{$param.Name}}, "{{$param.Name}}", {{$default}}, "{{$desc}}")
+	{{$set}}.{{$typeTitle}}Var(&{{$struct}}.{{$param.Name}}, "{{$param.Name}}", {{$defaultVar}}, "{{$desc}}")
 		{{- end }}
 		{{- end }}
 		{{- end }}

--- a/templates/testdata/cmd_env.go.txtar
+++ b/templates/testdata/cmd_env.go.txtar
@@ -13,14 +13,15 @@
       "Name": "verbose",
       "Type": "bool",
       "FlagAliases": ["v"],
+      "EnvVars": ["MY_VERBOSE"],
       "Description": "Enable verbose output"
     },
     {
-      "Name": "files",
-      "Type": "string",
-      "IsPositional": true,
-      "IsVarArg": true,
-      "Description": "Input files"
+      "Name": "count",
+      "Type": "int",
+      "EnvVars": ["MY_COUNT"],
+      "Default": "10",
+      "Description": "Count"
     }
   ]
 }
@@ -47,7 +48,7 @@ type MyCmd struct {
 	*RootCmd
 	Flags         *flag.FlagSet
 	verbose       bool
-	files         []string
+	count         int
 	SubCommands   map[string]Cmd
 	CommandAction func(c *MyCmd) error
 }
@@ -77,11 +78,9 @@ func (c *MyCmd) Execute(args []string) error {
 			return cmd.Execute(args[1:])
 		}
 	}
-	var remainingArgs []string
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
 		if arg == "--" {
-			remainingArgs = append(remainingArgs, args[i+1:]...)
 			break
 		}
 		if strings.HasPrefix(arg, "-") && arg != "-" {
@@ -107,24 +106,28 @@ func (c *MyCmd) Execute(args []string) error {
 				} else {
 					c.verbose = true
 				}
+
+			case "count":
+				if !hasValue {
+					if i+1 < len(args) {
+						value = args[i+1]
+						i++
+					} else {
+						return fmt.Errorf("flag %s requires a value", name)
+					}
+				}
+				iv, err := strconv.Atoi(value)
+				if err != nil {
+					return fmt.Errorf("invalid integer value for flag %s: %s", name, value)
+				}
+				c.count = iv
 			case "help", "h":
 				c.Usage()
 				return nil
 			default:
 				return fmt.Errorf("unknown flag: %s", name)
 			}
-		} else {
-			remainingArgs = append(remainingArgs, arg)
 		}
-	}
-	// Handle vararg files
-	{
-		varArgStart := 0
-		if varArgStart > len(remainingArgs) {
-			varArgStart = len(remainingArgs)
-		}
-		varArgs := remainingArgs[varArgStart:]
-		c.files = varArgs
 	}
 
 	if c.CommandAction != nil {
@@ -147,12 +150,25 @@ func (c *RootCmd) NewMyCmd() *MyCmd {
 	}
 
 	verboseDefault := false
+	if v := os.Getenv("MY_VERBOSE"); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			verboseDefault = b
+		}
+	}
 	set.BoolVar(&v.verbose, "v", verboseDefault, "Enable verbose output")
+
+	countDefault := 10
+	if v := os.Getenv("MY_COUNT"); v != "" {
+		if i, err := strconv.Atoi(v); err == nil {
+			countDefault = i
+		}
+	}
+	set.IntVar(&v.count, "count", countDefault, "Count")
 	set.Usage = v.Usage
 
 	v.CommandAction = func(c *MyCmd) error {
 
-		mypkg.MyCmdFunc(c.verbose, c.files...)
+		mypkg.MyCmdFunc(c.verbose, c.count)
 		return nil
 	}
 

--- a/templates/testdata/cmd_positional.go.txtar
+++ b/templates/testdata/cmd_positional.go.txtar
@@ -148,7 +148,8 @@ func (c *RootCmd) NewMyCmd() *MyCmd {
 		SubCommands: make(map[string]Cmd),
 	}
 
-	set.BoolVar(&v.verbose, "v", false, "Enable verbose output")
+	verboseDefault := false
+	set.BoolVar(&v.verbose, "v", verboseDefault, "Enable verbose output")
 	set.Usage = v.Usage
 
 	v.CommandAction = func(c *MyCmd) error {

--- a/templates/testdata/cmd_simple.go.txtar
+++ b/templates/testdata/cmd_simple.go.txtar
@@ -125,7 +125,8 @@ func (c *RootCmd) NewMyCmd() *MyCmd {
 		SubCommands: make(map[string]Cmd),
 	}
 
-	set.BoolVar(&v.verbose, "v", false, "Enable verbose output")
+	verboseDefault := false
+	set.BoolVar(&v.verbose, "v", verboseDefault, "Enable verbose output")
 	set.Usage = v.Usage
 
 	v.CommandAction = func(c *MyCmd) error {

--- a/templates/testdata/cmd_types.go.txtar
+++ b/templates/testdata/cmd_types.go.txtar
@@ -171,15 +171,19 @@ func (c *RootCmd) NewMyCmd() *MyCmd {
 		SubCommands: make(map[string]Cmd),
 	}
 
+	var timeoutDefault time.Duration
 	if d, err := time.ParseDuration("1s"); err == nil {
-		set.DurationVar(&v.timeout, "t", d, "Timeout duration")
+		timeoutDefault = d
 	} else {
-		set.DurationVar(&v.timeout, "t", 0, "Timeout duration")
+		timeoutDefault = 0
 	}
+	set.DurationVar(&v.timeout, "t", timeoutDefault, "Timeout duration")
 
-	set.IntVar(&v.count, "count", 3, "Retry count")
+	countDefault := 3
+	set.IntVar(&v.count, "count", countDefault, "Retry count")
 
-	set.StringVar(&v.config, "config", "config.yaml", "Config file")
+	configDefault := "config.yaml"
+	set.StringVar(&v.config, "config", configDefault, "Config file")
 	set.Usage = v.Usage
 
 	v.CommandAction = func(c *MyCmd) error {

--- a/templates/testdata/issue50.go.txtar
+++ b/templates/testdata/issue50.go.txtar
@@ -107,7 +107,8 @@ func NewRoot(name, version, commit, date string) (*RootCmd, error) {
 	}
 	c.FlagSet.Usage = c.Usage
 
-	c.BoolVar(&c.verbose, "verbose", false, "Enable verbose output")
+	verboseDefault := false
+	c.BoolVar(&c.verbose, "verbose", verboseDefault, "Enable verbose output")
 
 	c.Commands["sub1"] = c.NewSub1()
 	c.Commands["help"] = &InternalCommand{


### PR DESCRIPTION
This PR adds support for setting default values for flags using environment variables.
Syntax: `// flag: --flag (env: MY_ENV_VAR)`
Supported types: string, int, bool, time.Duration.
Multiple env vars per flag are supported (last set wins), though simple usage is recommended.
The generated code initializes a default variable, checks env vars, and then registers the flag with the computed default.
Also fixed an issue where `regexp` was compiled repeatedly in `parseParamDetails`.
Updated `templates/testdata` and added `cmd_env.go.txtar`.
Regenerated `gosubc`.


---
*PR created automatically by Jules for task [17249862316140533790](https://jules.google.com/task/17249862316140533790) started by @arran4*