### PR TITLE
Fix generated imports for slice types and clean up tests

### DIFF
--- a/issues_test.go
+++ b/issues_test.go
@@ -1,8 +1,6 @@
 package go_subcommand
 
 import (
-	"io/fs"
-	"os"
 	"strings"
 	"testing"
 	"testing/fstest"
@@ -10,75 +8,6 @@ import (
 	"github.com/arran4/go-subcommand/model"
 	"github.com/arran4/go-subcommand/parsers/commentv1"
 )
-
-// MockWriter implements FileWriter for in-memory testing
-type MockWriter struct {
-	Files map[string][]byte
-}
-
-func NewMockWriter() *MockWriter {
-	return &MockWriter{
-		Files: make(map[string][]byte),
-	}
-}
-
-func (m *MockWriter) WriteFile(path string, content []byte, perm os.FileMode) error {
-	m.Files[path] = content
-	return nil
-}
-
-func (m *MockWriter) MkdirAll(path string, perm os.FileMode) error {
-	return nil // No-op for map
-}
-
-type mockDirEntry struct {
-	name  string
-	isDir bool
-}
-
-func (d *mockDirEntry) Name() string { return d.name }
-func (d *mockDirEntry) IsDir() bool  { return d.isDir }
-func (d *mockDirEntry) Type() fs.FileMode {
-	if d.isDir {
-		return fs.ModeDir
-	}
-	return 0
-}
-func (d *mockDirEntry) Info() (fs.FileInfo, error) { return nil, nil }
-
-func (m *MockWriter) ReadFile(path string) ([]byte, error) {
-	if content, ok := m.Files[path]; ok {
-		return content, nil
-	}
-	return nil, os.ErrNotExist
-}
-
-func (m *MockWriter) ReadDir(path string) ([]fs.DirEntry, error) {
-	var entries []fs.DirEntry
-	seen := make(map[string]bool)
-	// Normalize path to have trailing slash if not empty
-	prefix := path
-	if prefix != "" && !strings.HasSuffix(prefix, "/") {
-		prefix += "/"
-	}
-
-	for k := range m.Files {
-		if strings.HasPrefix(k, prefix) {
-			rel := strings.TrimPrefix(k, prefix)
-			parts := strings.Split(rel, "/")
-			if len(parts) > 0 && parts[0] != "" {
-				name := parts[0]
-				if seen[name] {
-					continue
-				}
-				seen[name] = true
-				isDir := len(parts) > 1
-				entries = append(entries, &mockDirEntry{name: name, isDir: isDir})
-			}
-		}
-	}
-	return entries, nil
-}
 
 // setupProject returns an in-memory FS
 func setupProject(t *testing.T, sourceCode string) fstest.MapFS {
@@ -89,8 +18,8 @@ func setupProject(t *testing.T, sourceCode string) fstest.MapFS {
 }
 
 // runGenerateInMemory runs the generator using in-memory FS and Writer
-func runGenerateInMemory(t *testing.T, inputFS fstest.MapFS) *MockWriter {
-	writer := NewMockWriter()
+func runGenerateInMemory(t *testing.T, inputFS fstest.MapFS) *CollectingFileWriter {
+	writer := NewCollectingFileWriter()
 	// We use a dummy dir name like "." or "/app"
 	if err := GenerateWithFS(inputFS, writer, ".", "", "commentv1", nil, false); err != nil {
 		t.Fatalf("Generate failed: %v", err)
@@ -105,7 +34,7 @@ func TestIssue33_HyphenatedCommands_Content(t *testing.T) {
 func ListHeads() {}
 `
 	fs := setupProject(t, src)
-	writer := NewMockWriter()
+	writer := NewCollectingFileWriter()
 
 	err := GenerateWithFS(fs, writer, ".", "", "commentv1", nil, false)
 
@@ -916,7 +845,7 @@ func Child() {}
 		"main.go": &fstest.MapFile{Data: []byte(src)},
 	}
 
-	writer := NewMockWriter()
+	writer := NewCollectingFileWriter()
 	// Generate code
 	if err := GenerateWithFS(fs, writer, ".", "", "commentv1", nil, false); err != nil {
 		t.Fatalf("Generate failed: %v", err)
@@ -950,25 +879,25 @@ func Child() {}
 
 func TestGenerate_OverwriteProtection(t *testing.T) {
 	src := `package main
-// Cmd is a subcommand ` + "`app cmd`" + `
-func Cmd() {}
+// MyCmd is a subcommand ` + "`app mycmd`" + `
+func MyCmd() {}
 `
 	fs := setupProject(t, src)
 
 	// 1. Initial generation
-	writer := NewMockWriter()
+	writer := NewCollectingFileWriter()
 	err := GenerateWithFS(fs, writer, ".", "", "commentv1", nil, false)
 	if err != nil {
 		t.Fatalf("Initial generation failed: %v", err)
 	}
 
-	cmdFile := "cmd/app/cmd.go"
+	cmdFile := "cmd/app/mycmd.go"
 	if _, ok := writer.Files[cmdFile]; !ok {
 		t.Fatalf("File %s not generated", cmdFile)
 	}
 
 	// 2. Modify file (simulating manual edit removing header)
-	writer.Files[cmdFile] = []byte("package main\n// Manual edit\nfunc Cmd() {}")
+	writer.Files[cmdFile] = []byte("package main\n// Manual edit\nfunc MyCmd() {}")
 
 	// 3. Generate without force -> Should fail
 	err = GenerateWithFS(fs, writer, ".", "", "commentv1", nil, false)

--- a/recursive_paths_test.go
+++ b/recursive_paths_test.go
@@ -21,7 +21,7 @@ func Sub() {}
 	}
 
 	// Test recursive=true (default)
-	writer := NewMockWriter()
+	writer := NewCollectingFileWriter()
 	err := GenerateWithFS(fs, writer, ".", "", "commentv1", &parsers.ParseOptions{Recursive: true}, false)
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
@@ -31,7 +31,7 @@ func Sub() {}
 	}
 
 	// Test recursive=false
-	writer = NewMockWriter()
+	writer = NewCollectingFileWriter()
 	err = GenerateWithFS(fs, writer, ".", "", "commentv1", &parsers.ParseOptions{Recursive: false}, false)
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
@@ -59,7 +59,7 @@ func Cmd2() {}
 	}
 
 	// Test with specific path
-	writer := NewMockWriter()
+	writer := NewCollectingFileWriter()
 	err := GenerateWithFS(fs, writer, ".", "", "commentv1", &parsers.ParseOptions{
 		SearchPaths: []string{"pkg1"},
 		Recursive:   true,

--- a/templates/common/common.gotmpl
+++ b/templates/common/common.gotmpl
@@ -7,7 +7,12 @@
 	{{- if eq .Type "time.Duration" }}
 	{{- $hasDuration = true }}
 	{{- end }}
-	{{- if or (eq .Type "int") (eq .Type "bool") }}
+	{{- if eq .Type "[]time.Duration" }}
+		{{- if $needStrconvForFlags }}
+		{{- $hasDuration = true }}
+		{{- end }}
+	{{- end }}
+	{{- if or (eq .Type "int") (eq .Type "bool") (eq .Type "[]int") (eq .Type "[]bool") }}
 		{{- if or .IsPositional $needStrconvForFlags }}
 		{{- $hasStrconv = true }}
 		{{- end }}

--- a/templates/generation_test.go
+++ b/templates/generation_test.go
@@ -115,53 +115,6 @@ func TestGoTemplates(t *testing.T) {
 			if err != nil {
 				t.Errorf("Generated code is not valid Go: %v\nCode:\n%s", err, buf.String())
 			} else {
-				// We want to ensure the generated output IS formatted.
-				// So we compare buf.Bytes() (generated) with formatted.
-				// However, templates are hard to get perfectly formatted (indentation etc).
-				// The `generate.go` file does `format.Source` on the output.
-				// The user said: "use the ast to automatically run the source formatter against the output and compare it to itself as part of these tests to ensure that the output is complaint to go formatting requirements."
-
-				// "compare it to itself" is vague.
-				// "Compare (formatted output) to (itself)"? No.
-				// "Compare (output) to (formatted output)"? This means output must be already formatted.
-				// BUT `generate.go` runs `format.Source`.
-				// If this test is testing the *templates*, the templates might produce unformatted code that `generate.go` fixes.
-				// If the user wants to test the templates *output* compliance, maybe they want to ensure templates produce close-to-formatted code?
-				// OR, they want to ensure the *expected output in txtar* is formatted.
-
-				// Re-reading: "use the ast to automatically run the source formatter against the output and compare it to itself ... to ensure that the output is complaint"
-				// Maybe they mean: "Ensure that `format.Source(output)` succeeds (is compliant)".
-				// AND "compare it to itself" -> maybe compare the `txtar` expected output to the formatted result?
-
-				// Let's assume the test should:
-				// 1. Generate code from template.
-				// 2. Format it using `format.Source`.
-				// 3. Compare the *formatted* code against the `output.go` in txtar.
-				// This matches how `generate.go` works (it formats before writing).
-				// So `output.go` in txtar should be the formatted code.
-
-				// But wait, "compare it to itself" might mean:
-				// `formatted := format(generated)`
-				// `if generated != formatted { fail }`
-				// This would enforce that the template ITSELF produces formatted code without needing `format.Source`.
-				// This is a much stricter requirement.
-				// Given "Without solving any tests...", if I add this check and templates are messy, tests will fail.
-				// But `generate.go` explicitly uses `format.Source`.
-				// So typically templates produce rough code and we format it.
-				// Checking if `generated == formatted` would fail if templates rely on `format.Source`.
-
-				// Let's look at the existing `usage_test.go`. It compares generated output to txtar output.
-				// Usage text is not Go code, so no formatting.
-
-				// User said: "ensure that the output is complaint to go formatting requirements".
-				// This usually means "it is valid go code that can be formatted".
-
-				// I will do this:
-				// 1. Generate `raw`.
-				// 2. Format `raw` -> `formatted`. If error, fail (invalid go).
-				// 3. Compare `formatted` to `expectedOutput`.
-				// This ensures we test the final result (what users get).
-
 				if !bytes.Equal(formatted, expectedOutput) {
 					t.Errorf("Output mismatch for %s:\nExpected:\n%s\nGot:\n%s", entry.Name(), string(expectedOutput), string(formatted))
 				}


### PR DESCRIPTION
This PR resolves the user request to remove "verbiage" from `templates/generation_test.go`. It also addresses the underlying issue that the verbiage was discussing: generated code was missing imports for slice types, causing `format.Source` to potentially fail (or produce invalid code).

Additionally, this PR fixes several compilation errors in the test suite (`mockDirEntry` redeclaration) and consolidates filesystem mocking by using `CollectingFileWriter` instead of a redundant `MockWriter` in tests.


---
*PR created automatically by Jules for task [4281141556088809425](https://jules.google.com/task/4281141556088809425) started by @arran4*