### PR TITLE
Fix build failure by renaming conflicting mockDirEntry struct

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -99,7 +99,7 @@ func (w *CollectingFileWriter) ReadDir(path string) ([]fs.DirEntry, error) {
 			seen[name] = true
 			isDir := len(parts) > 1
 			// We only have minimal info for the mock DirEntry
-			entries = append(entries, &mockDirEntry{name: name, isDir: isDir})
+			entries = append(entries, &collectingDirEntry{name: name, isDir: isDir})
 		}
 	}
 	// Also check known directories
@@ -112,7 +112,7 @@ func (w *CollectingFileWriter) ReadDir(path string) ([]fs.DirEntry, error) {
 				continue
 			}
 			seen[name] = true
-			entries = append(entries, &mockDirEntry{name: name, isDir: true})
+			entries = append(entries, &collectingDirEntry{name: name, isDir: true})
 		}
 	}
 
@@ -142,20 +142,20 @@ func (w *CollectingFileWriter) ReadDir(path string) ([]fs.DirEntry, error) {
 	return entries, nil
 }
 
-type mockDirEntry struct {
+type collectingDirEntry struct {
 	name  string
 	isDir bool
 }
 
-func (d *mockDirEntry) Name() string { return d.name }
-func (d *mockDirEntry) IsDir() bool  { return d.isDir }
-func (d *mockDirEntry) Type() fs.FileMode {
+func (d *collectingDirEntry) Name() string { return d.name }
+func (d *collectingDirEntry) IsDir() bool  { return d.isDir }
+func (d *collectingDirEntry) Type() fs.FileMode {
 	if d.isDir {
 		return fs.ModeDir
 	}
 	return 0
 }
-func (d *mockDirEntry) Info() (fs.FileInfo, error) { return nil, nil }
+func (d *collectingDirEntry) Info() (fs.FileInfo, error) { return nil, nil }
 
 func (w *CollectingFileWriter) Verify(writer FileWriter, force bool) error {
 	for path, content := range w.Files {


### PR DESCRIPTION
Renamed `mockDirEntry` to `collectingDirEntry` in `generate.go` to fix build failure due to redeclaration. Validated that tests pass and verified template generation does not produce duplicated code (as reported in the secondary issue which could not be reproduced and is likely an environmental artifact).

---
*PR created automatically by Jules for task [16514920959930463737](https://jules.google.com/task/16514920959930463737) started by @arran4*