### PR TITLE
Verify issue #310 is resolved and add regression test

### DIFF
--- a/templates/usage_test.go
+++ b/templates/usage_test.go
@@ -94,6 +94,11 @@ func TestUsageTemplate(t *testing.T) {
 				t.Fatalf("failed to execute template: %v", err)
 			}
 
+			// Verify the generated content is a valid template
+			if _, err := template.New("generated").Parse(buf.String()); err != nil {
+				t.Errorf("Generated content is not a valid template: %v\nContent:\n%s", err, buf.String())
+			}
+
 			if !bytes.Equal(buf.Bytes(), expectedOutput) {
 				t.Errorf("Output mismatch for %s:\nExpected:\n%q\nGot:\n%q", entry.Name(), string(expectedOutput), buf.String())
 			}


### PR DESCRIPTION
Verified that issue #310 is resolved in the current codebase. Added a regression test in `templates/usage_test.go` that parses the generated usage text as a Go template to ensure it is valid. Verified that the test passes with the current code and fails if the invalid syntax is reintroduced.


---
*PR created automatically by Jules for task [10700385476484539272](https://jules.google.com/task/10700385476484539272) started by @arran4*