### PR TITLE
chore: update generate_pr workflow to close generated PRs on parent close

### DIFF
--- a/templates/github/workflows/generate_pr.yml.gotmpl
+++ b/templates/github/workflows/generate_pr.yml.gotmpl
@@ -2,7 +2,9 @@
 name: Generate PR
 
 on:
-  push
+  push:
+  pull_request:
+    types: [closed]
 
 permissions:
   contents: write
@@ -11,6 +13,7 @@ permissions:
 jobs:
   generate-pr:
     name: Generate PR
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -47,3 +50,17 @@ jobs:
           body: "This PR updates the generated code to match the current generator logic."
           branch: update-generated-code-${{ "{{" }} github.ref_name {{ "}}" }}
           delete-branch: true
+
+  close-generated-pr:
+    name: Close Generated PR
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close Generated PR
+        env:
+          GH_TOKEN: ${{ "{{" }} secrets.GITHUB_TOKEN {{ "}}" }}
+        run: |
+          BRANCH_NAME="${{ "{{" }} github.event.pull_request.head.ref {{ "}}" }}"
+          GENERATED_BRANCH="update-generated-code-${BRANCH_NAME}"
+          echo "Closing PR for branch $GENERATED_BRANCH"
+          gh pr close "$GENERATED_BRANCH" --comment "Parent PR closed." --delete-branch || true


### PR DESCRIPTION
Updates `templates/github/workflows/generate_pr.yml.gotmpl` to add a `close-generated-pr` job that triggers on `pull_request` closed events. This job uses the GitHub CLI to close the associated generated PR. The main generation job is now guarded to run only on `push` events. This ensures that generated PRs for feature branches are cleaned up when the feature branch is merged or closed, and the generated PR for `main` is kept up-to-date.

---
*PR created automatically by Jules for task [16085949561725344908](https://jules.google.com/task/16085949561725344908) started by @arran4*