### PR TITLE
Handle lowercase 'aliases:' headers in comment parser

### DIFF
--- a/parsers/commentv1/commentv1.go
+++ b/parsers/commentv1/commentv1.go
@@ -631,7 +631,8 @@ func ParseSubCommandComments(text string) (cmdName string, subCommandSequence []
 			continue
 		}
 
-		if strings.HasPrefix(trimmedLine, "Aliases:") || strings.HasPrefix(trimmedLine, "Alias:") {
+		lowerTrimmedLine := strings.ToLower(trimmedLine)
+		if strings.HasPrefix(lowerTrimmedLine, "aliases:") || strings.HasPrefix(lowerTrimmedLine, "alias:") {
 			lineParts := strings.SplitN(trimmedLine, ":", 2)
 			if len(lineParts) > 1 {
 				parts := strings.Split(lineParts[1], ",")

--- a/parsers/commentv1/parser_test.go
+++ b/parsers/commentv1/parser_test.go
@@ -45,6 +45,15 @@ func TestParseSubCommandComments(t *testing.T) {
 			wantOk:                 true,
 		},
 		{
+			name:                   "With Lowercase Aliases Header",
+			text:                   "Cmd is a subcommand `app cmd` -- Description\naliases: c, command",
+			wantCmdName:            "app",
+			wantSubCommandSequence: []string{"cmd"},
+			wantDescription:        "Description",
+			wantAliases:            []string{"c", "command"},
+			wantOk:                 true,
+		},
+		{
 			name:                   "Example 1.1",
 			text:                   "ExampleCmd1 is a subcommand `basic1 example1`",
 			wantCmdName:            "basic1",


### PR DESCRIPTION
### Motivation
- The comment parser treated lowercase `aliases:`/`alias:` header lines as extended help text, causing inline alias metadata to be missed for commands documented with a lowercase header.

### Description
- Added an edge-case test for `ParseSubCommandComments` that includes a lowercase `aliases:` header and updated the parser to check a lowercase-normalized `trimmedLine` so header detection is case-insensitive, preserving the rest of the parsing behavior (files changed: `parsers/commentv1/commentv1.go`, `parsers/commentv1/parser_test.go`).

### Testing
- Ran the failing targeted test before the fix which exposed the issue and then verified the test passes after the change with `go test ./parsers/commentv1 -run TestParseSubCommandComments/With_Lowercase_Aliases_Header` and the full suite with `go test ./...`, both succeeding; `golangci-lint run` reported an environment/toolchain mismatch in this environment and was not used as a blocking check.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997b2c220b8832fb1feaa1267802f25)