### PR TITLE
fix: group usage flags by parent/child command and improve inheritance support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 ## Code Generation & Testing
 * **Keep README.md and txtar tests up to date:** When adding new features, ensure that the `README.md` documentation and `txtar` tests (in `templates/testdata`) are updated to reflect the changes. This helps maintain a comprehensive regression suite and up-to-date documentation.
+* **Embed Large Test Data:** When writing unit tests (e.g., in `issues_test.go` or new test files) that require significant source code strings, put the source code in a file within the `testdata/` directory and use `//go:embed` to load it. This avoids large, messy string literals in test files and potential file system issues.
+* **Avoid Disk I/O in Tests:** Use `testing/fstest.MapFS` and in-memory writers (like `CollectingFileWriter`) for tests instead of reading/writing actual files to the disk. This ensures tests are hermetic and faster. If you need to test file system interactions, mock the file system interface.
 
 ## Tooling Generation (Bootstrapping)
 

--- a/issue330_test.go
+++ b/issue330_test.go
@@ -1,32 +1,16 @@
 package go_subcommand
 
 import (
+	_ "embed"
 	"strings"
 	"testing"
 )
 
-func TestIssue330_ParentFlagsReporting(t *testing.T) {
-	src := "package main\n" +
-        "\n" +
-        "// Parent is a subcommand `app parent` that Does work in a directory\n" +
-        "//\n" +
-        "// Flags:\n" +
-        "//\n" +
-        "//\tdir: --dir (default: \".\") The directory\n" +
-        "func Parent(dir string) {}\n" +
-        "\n" +
-        "// Child is a subcommand `app parent child` that Does work in a directory\n" +
-        "//\n" +
-        "// Flags:\n" +
-        "//\n" +
-        "//\tdir: --dir (from parent)\n" +
-        "//\ti: --i (default: 0) A random int\n" +
-        "func Child(dir string, i int) {}\n" +
-        "\n" +
-        "// GrandChild is a subcommand `app parent child grandchild`\n" +
-        "func GrandChild() {}\n"
+//go:embed testdata/issue330.go
+var issue330Src string
 
-	fs := setupProject(t, src)
+func TestIssue330_ParentFlagsReporting(t *testing.T) {
+	fs := setupProject(t, issue330Src)
 	writer := runGenerateInMemory(t, fs)
 
 	// Check Child usage
@@ -47,53 +31,35 @@ func TestIssue330_ParentFlagsReporting(t *testing.T) {
 		t.Error("Missing '`parent` Flags:' section in usage")
 	}
 
-    // Check that --dir is under parent Flags
-    parentIndex := strings.Index(usageText, "`parent` Flags:")
-    childIndex := strings.Index(usageText, "`child` Flags:")
-    dirIndex := strings.Index(usageText, "--dir")
+	// Check that --dir is under parent Flags
+	parentIndex := strings.Index(usageText, "`parent` Flags:")
+	childIndex := strings.Index(usageText, "`child` Flags:")
+	dirIndex := strings.Index(usageText, "--dir")
 
-    if parentIndex == -1 || childIndex == -1 || dirIndex == -1 {
-        // Assertions above already cover missing sections
-    } else {
-        if dirIndex < parentIndex || (childIndex > parentIndex && dirIndex > childIndex) {
-            // Wait, order: parent comes BEFORE child in usage usually if root->leaf?
-            // My implementation iterates root->leaf. So Parent comes before Child.
-            // So `parent` Flags: ... --dir ... `child` Flags: ...
-            // So dirIndex > parentIndex AND dirIndex < childIndex.
+	if parentIndex != -1 && childIndex != -1 && dirIndex != -1 {
+		if dirIndex < parentIndex {
+			t.Error("--dir flag appears before `parent` Flags: header")
+		}
+		if dirIndex > childIndex {
+			t.Error("--dir flag appears after `child` Flags: header (should be under parent)")
+		}
+	}
 
-            // Wait, iteration order in `FullUsageString` is root->leaf.
-            // `ParameterGroups` also orders root->leaf.
-            // So: `app` -> `parent` -> `child`.
-            // Usage output:
-            // `parent` Flags:
-            // ...
-            // `child` Flags:
-            // ...
+	// Check GrandChild usage
+	gcUsagePath := "cmd/app/templates/grandchild_usage.txt"
+	gcContent, ok := writer.Files[gcUsagePath]
+	if !ok {
+		t.Fatalf("Usage file not found: %s", gcUsagePath)
+	}
+	gcUsageText := string(gcContent)
 
-            if dirIndex < parentIndex {
-                 t.Error("--dir flag appears before `parent` Flags: header")
-            }
-            if dirIndex > childIndex {
-                 t.Error("--dir flag appears after `child` Flags: header (should be under parent)")
-            }
-    }
-    }
-
-    // Check GrandChild usage
-    gcUsagePath := "cmd/app/templates/grandchild_usage.txt"
-    gcContent, ok := writer.Files[gcUsagePath]
-    if !ok {
-        t.Fatalf("Usage file not found: %s", gcUsagePath)
-    }
-    gcUsageText := string(gcContent)
-
-    if !strings.Contains(gcUsageText, "`parent` Flags:") {
+	if !strings.Contains(gcUsageText, "`parent` Flags:") {
 		t.Error("Missing '`parent` Flags:' section in GrandChild usage")
 	}
-    if !strings.Contains(gcUsageText, "--dir") {
-        t.Error("GrandChild usage missing --dir (inherited)")
-    }
-    if !strings.Contains(gcUsageText, "The directory") {
-        t.Error("GrandChild usage missing inherited description for --dir")
-    }
+	if !strings.Contains(gcUsageText, "--dir") {
+		t.Error("GrandChild usage missing --dir (inherited)")
+	}
+	if !strings.Contains(gcUsageText, "The directory") {
+		t.Error("GrandChild usage missing inherited description for --dir")
+	}
 }

--- a/templates/cmd/templates/usage.txt.gotmpl
+++ b/templates/cmd/templates/usage.txt.gotmpl
@@ -29,10 +29,19 @@ Subcommands:
 {{- end}}
 {{end}}{{/* End Subcommands block */}}{{if .ParameterGroups}}
 {{$maxFlag := add .MaxFlagLength 2}}{{$maxDef := .MaxDefaultLength}}{{if gt $maxDef 0}}{{$maxDef = add $maxDef 2}}{{end}}
+{{- if eq (len .ParameterGroups) 1 -}}
+{{- range .ParameterGroups}}
+
+Flags:{{- range .Parameters}}
+{{printf "\n    %-*s %-*s %s" $maxFlag .FlagString $maxDef .DefaultString .Description}}
+{{- end}}
+{{- end}}
+{{- else -}}
 {{- range .ParameterGroups}}
 
 `{{.CommandName}}` Flags:{{- range .Parameters}}
 {{printf "\n    %-*s %-*s %s" $maxFlag .FlagString $maxDef .DefaultString .Description}}
+{{- end}}
 {{- end}}
 {{- end}}
 {{end}}{{$hasPositional := false}}{{range .Parameters}}{{if .IsPositional}}{{$hasPositional = true}}{{end}}{{end}}{{if $hasPositional}}

--- a/templates/testdata/alignment_long.txtar
+++ b/templates/testdata/alignment_long.txtar
@@ -57,7 +57,7 @@ Subcommands:
 
 
 
-`align` Flags:
+Flags:
 
     -s              (default: false)   Short flag
 

--- a/templates/testdata/complex_flags.txtar
+++ b/templates/testdata/complex_flags.txtar
@@ -39,7 +39,7 @@ Usage: flagsapp test [flags...]
 
 
 
-`test` Flags:
+Flags:
 
     --simple string                         Simple string flag
 

--- a/templates/testdata/functional.txtar
+++ b/templates/testdata/functional.txtar
@@ -79,7 +79,7 @@ Subcommands:
 
 
 
-`foo` Flags:
+Flags:
 
     -v       (default: false)   Enable verbose
 

--- a/templates/testdata/issue50_subcommand_usage.txtar
+++ b/templates/testdata/issue50_subcommand_usage.txtar
@@ -27,6 +27,6 @@ Subcommands:
 
 
 
-`sub1` Flags:
+Flags:
 
     -f    Force execution

--- a/templates/testdata/usage.txtar
+++ b/templates/testdata/usage.txtar
@@ -77,7 +77,7 @@ Subcommands:
 
 
 
-`foo` Flags:
+Flags:
 
     -v       (default: false)   Enable verbose
 

--- a/templates/testdata/usage_no_sub.txtar
+++ b/templates/testdata/usage_no_sub.txtar
@@ -32,7 +32,7 @@ Subcommands:
 
 
 
-`leaf` Flags:
+Flags:
 
     -f              (default: false)   Force action
 

--- a/testdata/issue330.go
+++ b/testdata/issue330.go
@@ -1,0 +1,19 @@
+package main
+
+// Parent is a subcommand `app parent` that Does work in a directory
+//
+// Flags:
+//
+//	dir: --dir (default: ".") The directory
+func Parent(dir string) {}
+
+// Child is a subcommand `app parent child` that Does work in a directory
+//
+// Flags:
+//
+//	dir: --dir (from parent)
+//	i: --i (default: 0) A random int
+func Child(d string, ir int) {}
+
+// GrandChild is a subcommand `app parent child grandchild`
+func GrandChild() {}


### PR DESCRIPTION
Implemented changes to group flags by command in the usage documentation as requested in issue #330.

Changes:
1.  Modified `model/model.go` to add `DeclaredIn` field to `FunctionParameter`, tracking the command name where the parameter originates.
2.  Added `ParameterGroup` struct and `ParameterGroups()` method to `SubCommand` model to group parameters by their source command.
3.  Added `FullUsageString()` method to `SubCommand` model to generate a usage line that iterates the command hierarchy (e.g., `app [flags] parent [flags] child`).
4.  Updated `parsers/commentv1/commentv1.go` to:
    *   Set `DeclaredIn` when parsing parameters.
    *   Detect `(from parent)` in parameter description comments and mark them as inherited.
    *   Implement a post-processing step `resolveInheritance` to populate missing descriptions/defaults/aliases for inherited parameters from their ancestors.
5.  Updated `templates/cmd/templates/usage.txt.gotmpl` to use `FullUsageString` and iterate over `ParameterGroups`, creating sections like `` `parent` Flags: ``.
6.  Verified with a new test `issue330_test.go` covering the reported scenario and ensured no regressions with existing tests.


---
*PR created automatically by Jules for task [5285301038558351104](https://jules.google.com/task/5285301038558351104) started by @arran4*