### PR TITLE
fix: alias imports in generated code to ensure correct package qualification

### DIFF
--- a/templates/cmd/cmd.go.gotmpl
+++ b/templates/cmd/cmd.go.gotmpl
@@ -16,7 +16,7 @@ import (
 {{- template "common_imports" (slice .AllParameters true) }}
 {{- if .ImportPath}}
 
-	"{{.ImportPath}}"
+	{{if and .SubCommandPackageName (ne .SubCommandPackageName "main")}}{{.SubCommandPackageName}} {{end}}"{{.ImportPath}}"
 {{- end}}
 	{{- if and .SubCommandFunctionName .ReturnsError}}
 	"errors"

--- a/templates/cmd/root.go.gotmpl
+++ b/templates/cmd/root.go.gotmpl
@@ -19,7 +19,7 @@ import (
 	"{{.PackagePath}}/cmd/{{.MainCmdName}}/templates"
 	{{- if .FunctionName}}
 	{{- if .ImportPath}}
-	"{{.ImportPath}}"
+	{{if and .CommandPackageName (ne .CommandPackageName "main")}}{{.CommandPackageName}} {{end}}"{{.ImportPath}}"
 	{{- end}}
 	{{- if .ReturnsError}}
 	"errors"

--- a/templates/testdata/cmd_error.go.txtar
+++ b/templates/testdata/cmd_error.go.txtar
@@ -27,7 +27,7 @@ import (
 	"strings"
 
 	"errors"
-	"example.com/mypkg"
+	mypkg "example.com/mypkg"
 	"example.com/myproject/cmd"
 )
 

--- a/templates/testdata/cmd_positional.go.txtar
+++ b/templates/testdata/cmd_positional.go.txtar
@@ -38,7 +38,7 @@ import (
 	"strconv"
 	"strings"
 
-	"example.com/mypkg"
+	mypkg "example.com/mypkg"
 )
 
 var _ Cmd = (*MyCmd)(nil)

--- a/templates/testdata/cmd_simple.go.txtar
+++ b/templates/testdata/cmd_simple.go.txtar
@@ -31,7 +31,7 @@ import (
 	"strconv"
 	"strings"
 
-	"example.com/mypkg"
+	mypkg "example.com/mypkg"
 )
 
 var _ Cmd = (*MyCmd)(nil)

--- a/templates/testdata/cmd_slices.go.txtar
+++ b/templates/testdata/cmd_slices.go.txtar
@@ -52,7 +52,7 @@ import (
 	"strings"
 	"time"
 
-	"example.com/mypkg"
+	mypkg "example.com/mypkg"
 )
 
 var _ Cmd = (*MySliceCmd)(nil)

--- a/templates/testdata/cmd_types.go.txtar
+++ b/templates/testdata/cmd_types.go.txtar
@@ -45,7 +45,7 @@ import (
 	"strings"
 	"time"
 
-	"example.com/mypkg"
+	mypkg "example.com/mypkg"
 )
 
 var _ Cmd = (*MyCmd)(nil)

--- a/templates/testdata/cmd_varargs.go.txtar
+++ b/templates/testdata/cmd_varargs.go.txtar
@@ -38,7 +38,7 @@ import (
 	"strconv"
 	"strings"
 
-	"example.com/mypkg"
+	mypkg "example.com/mypkg"
 )
 
 var _ Cmd = (*MyCmd)(nil)

--- a/templates/testdata/root_pkg_name.go.txtar
+++ b/templates/testdata/root_pkg_name.go.txtar
@@ -25,7 +25,7 @@ import (
 	"strings"
 
 	"example.com/myproject/cmd/mycmd/templates"
-	"example.com/myproject/rootpkg"
+	rootpkg "example.com/myproject/rootpkg"
 )
 
 type Cmd interface {


### PR DESCRIPTION
This PR fixes issue #328 where generated code could fail to compile due to incorrect package qualification in function calls.

The fix involves explicitly aliasing imports in the generated `root.go` and `cmd.go` files using the package name detected by the parser (`CommandPackageName` / `SubCommandPackageName`). This ensures that the function call, which uses this package name as a qualifier, always resolves to the correct imported package, even if the directory name differs from the package name.

I have verified the fix with a reproduction test case (which failed before the fix and passed after) and updated the existing golden file tests.

---
*PR created automatically by Jules for task [7531603855130349383](https://jules.google.com/task/7531603855130349383) started by @arran4*