### PR TITLE
Add parent PR link to generated PR description

### DIFF
--- a/templates/github/workflows/generate_pr.yml.gotmpl
+++ b/templates/github/workflows/generate_pr.yml.gotmpl
@@ -41,13 +41,24 @@ jobs:
             echo "No changes detected"
           fi
 
+      - name: Find Parent PR
+        id: find_pr
+        env:
+          GH_TOKEN: ${{ "{{" }} secrets.GITHUB_TOKEN {{ "}}" }}
+        run: |
+          BRANCH_NAME="${{ "{{" }} github.ref_name {{ "}}" }}"
+          PR_URL=$(gh pr list --head "$BRANCH_NAME" --state open --json url --jq '.[0].url')
+          echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ "{{" }} secrets.GITHUB_TOKEN {{ "}}" }}
           commit-message: "chore: update generated code"
           title: "chore: update generated code for ${{ "{{" }} github.ref_name {{ "}}" }}"
-          body: "This PR updates the generated code to match the current generator logic."
+          body: |
+            This PR updates the generated code to match the current generator logic.
+            Parent PR: ${{ "{{" }} steps.find_pr.outputs.pr_url {{ "}}" }}
           branch: update-generated-code-${{ "{{" }} github.ref_name {{ "}}" }}
           delete-branch: true
 


### PR DESCRIPTION
Updates the `generate_pr.yml.gotmpl` template to add a link to the parent PR in the description of the automatically generated PR.
- Adds a `Find Parent PR` step using `gh pr list`.
- Updates the `Create Pull Request` step to include the found URL in the PR body.

---
*PR created automatically by Jules for task [3949877177828552736](https://jules.google.com/task/3949877177828552736) started by @arran4*