### PR TITLE
fix(templates): remove extra line break in flags usage output

### DIFF
--- a/templates/cmd/templates/usage.txt.gotmpl
+++ b/templates/cmd/templates/usage.txt.gotmpl
@@ -32,14 +32,14 @@ Subcommands:
 {{- if eq (len .ParameterGroups) 1 -}}
 {{- range .ParameterGroups}}
 
-Flags:{{- range .Parameters}}
+Flags:{{- range .Parameters -}}
 {{printf "\n    %-*s %-*s %s" $maxFlag .FlagString $maxDef .DefaultString .Description}}
 {{- end}}
 {{- end}}
 {{- else -}}
 {{- range .ParameterGroups}}
 
-`{{.CommandName}}` Flags:{{- range .Parameters}}
+`{{.CommandName}}` Flags:{{- range .Parameters -}}
 {{printf "\n    %-*s %-*s %s" $maxFlag .FlagString $maxDef .DefaultString .Description}}
 {{- end}}
 {{- end}}

--- a/templates/testdata/alignment_long.txtar
+++ b/templates/testdata/alignment_long.txtar
@@ -58,9 +58,6 @@ Subcommands:
 
 
 Flags:
-
     -s              (default: false)   Short flag
-
     --long string                      This is a very long flag description to see how it wraps or aligns in the output when the flag name itself is quite long.
-
     --another int   (default: 42)      Another flag

--- a/templates/testdata/complex_flags.txtar
+++ b/templates/testdata/complex_flags.txtar
@@ -40,11 +40,7 @@ Usage: flagsapp test [flags...]
 
 
 Flags:
-
     --simple string                         Simple string flag
-
     -m, --mu, --multi     (default: true)   Flag with multiple aliases
-
     --no-alias int        (default: 10)     Flag without aliases
-
     --duration duration   (default: 1s)     Duration flag

--- a/templates/testdata/functional.txtar
+++ b/templates/testdata/functional.txtar
@@ -80,7 +80,5 @@ Subcommands:
 
 
 Flags:
-
     -v       (default: false)   Enable verbose
-
     -c int   (default: 0)       Count items

--- a/templates/testdata/issue50_subcommand_usage.txtar
+++ b/templates/testdata/issue50_subcommand_usage.txtar
@@ -28,5 +28,4 @@ Subcommands:
 
 
 Flags:
-
     -f    Force execution

--- a/templates/testdata/usage.txtar
+++ b/templates/testdata/usage.txtar
@@ -78,7 +78,5 @@ Subcommands:
 
 
 Flags:
-
     -v       (default: false)   Enable verbose
-
     -c int   (default: 0)       Count items

--- a/templates/testdata/usage_no_sub.txtar
+++ b/templates/testdata/usage_no_sub.txtar
@@ -33,7 +33,6 @@ Subcommands:
 
 
 Flags:
-
     -f              (default: false)   Force action
 
 Positional Arguments:


### PR DESCRIPTION
Fixed an issue where the generated usage text for flags contained double line breaks between flags. This was caused by the `range` loop in the `usage.txt.gotmpl` template preserving the newline character from the template source file in addition to the newline printed by `printf`.

Changes:
- Modified `templates/cmd/templates/usage.txt.gotmpl` to use `{{- range .Parameters -}}` (added trailing `-`) to consume the trailing whitespace.
- Updated `templates/testdata/*.txtar` files to match the new single-spaced output.

---
*PR created automatically by Jules for task [1219441454606909190](https://jules.google.com/task/1219441454606909190) started by @arran4*