### PR TITLE
chore: Fix github-pages deploy error on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,7 @@ jobs:
   hugo-deploy:
     name: Deploy to GitHub Pages
     needs: [route, hugo-build]
-    if: ${{ needs.route.outputs.run_pages == 'true' }}
+    if: ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch') && needs.route.outputs.run_pages == 'true' }}
     runs-on: ubuntu-latest
     concurrency:
       group: pages


### PR DESCRIPTION
The `hugo-deploy` job in the `.github/workflows/ci.yml` is configured to use the `github-pages` environment, which requires deployments to happen only on specific branches (like `main` and `master`).
Previously, the `hugo-deploy` job only checked if `needs.route.outputs.run_pages == 'true'`, but GitHub Actions validates environment rules upon workflow trigger. This resulted in PRs failing immediately because the PR branch wasn't allowed to deploy to `github-pages`.

This commit adds a statically evaluable condition (`github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'`) to the `hugo-deploy` job's `if` condition, which allows the job to be properly skipped on PRs without triggering the environment protection error.

---
*PR created automatically by Jules for task [8253336100493091254](https://jules.google.com/task/8253336100493091254) started by @arran4*