### PR TITLE
ci: update goreleaser-action for v2 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -589,7 +589,7 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' && startsWith(inputs.mode, 'release-') }}
         run: git tag -f ${{ needs.prepare-release-tag.outputs.release_tag }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v7
         with:
           version: '~> v2'
           args: release --clean

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -591,7 +591,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:
-          version: latest
-          args: release --rm-dist
+          version: '~> v2'
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Updates the GoReleaser GitHub Action to use version `~> v2` so it can properly parse `.goreleaser.yml` fields introduced in v2 like `homebrew_casks`. Also replaces the deprecated `--rm-dist` flag with `--clean`.

---
*PR created automatically by Jules for task [17471518327491510593](https://jules.google.com/task/17471518327491510593) started by @arran4*