### PR TITLE
Fix github pages deploy issue on non-main branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,7 @@ jobs:
   hugo-deploy:
     name: Deploy to GitHub Pages
     needs: [route, hugo-build]
-    if: ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch') && needs.route.outputs.run_pages == 'true' }}
+    if: ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) && needs.route.outputs.run_pages == 'true' }}
     runs-on: ubuntu-latest
     concurrency:
       group: pages


### PR DESCRIPTION
Fixes an issue where `hugo-deploy` would mistakenly attempt to deploy from non-main branches (such as PRs) due to the presence of the `github.event_name == 'workflow_dispatch'` condition. By removing this condition from the `if` block, we restrict GitHub Pages deployment solely to `main`, `master`, and tags, preventing environment protection errors.

---
*PR created automatically by Jules for task [4928418421662474991](https://jules.google.com/task/4928418421662474991) started by @arran4*