### PR TITLE
ci: Fix github pages deployment error on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,13 +263,13 @@ jobs:
   hugo-deploy:
     name: Deploy to GitHub Pages
     needs: [route, hugo-build]
-    if: ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) && needs.route.outputs.run_pages == 'true' }}
+    if: ${{ github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) && needs.route.outputs.run_pages == 'true' }}
     runs-on: ubuntu-latest
     concurrency:
       group: pages
       cancel-in-progress: false
     environment:
-      name: github-pages
+      name: ${{ github.event_name != 'pull_request' && 'github-pages' || '' }}
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
This PR dynamically sets the `environment` block's name to an empty string on `pull_request` events to avoid triggering branch protection rules meant for the `github-pages` environment on PR runs. This prevents the "deployment rejected" status check from displaying on PRs.

---
*PR created automatically by Jules for task [5198862924803450165](https://jules.google.com/task/5198862924803450165) started by @arran4*