### PR TITLE
docs: clarify gosubc is a CLI tool, not a library dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Go Subcommand
 
-**Go Subcommand** generates subcommand code for command-line interfaces (CLIs) in Go from source code comments. By leveraging specially formatted code comments, it automatically generates a dependency-less subcommand system, allowing you to focus on your application's core logic instead of boilerplate code.
+**Go Subcommand** (`gosubc`) is a command-line code generation tool that creates subcommand code for command-line interfaces (CLIs) in Go from source code comments. **It is designed to be installed and run as a standalone executable during your build process (e.g., via `go generate`), not imported as a library dependency in your Go code.**
+
+By leveraging specially formatted code comments, it automatically generates a dependency-less subcommand system, allowing you to focus on your application's core logic instead of boilerplate code.
 
 **Status:** Pre-v1. The API and generated code structure may change.
 


### PR DESCRIPTION
This change updates the README to make it clear that `gosubc` is a standalone command-line code generation tool and not meant to be imported as a library dependency.

---
*PR created automatically by Jules for task [5907357953575255363](https://jules.google.com/task/5907357953575255363) started by @arran4*