### PR TITLE
ci: update peaceiris/actions-hugo to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,7 +243,7 @@ jobs:
           submodules: recursive
           fetch-depth: 0
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v2
+        uses: peaceiris/actions-hugo@v3
         with:
           hugo-version: 'latest'
           extended: true


### PR DESCRIPTION
This PR updates the version of `peaceiris/actions-hugo` used in `.github/workflows/ci.yml` from `v2` to `v3`. This fixes an issue where Node 20 deprecation warnings and API fetch failures were breaking the `hugo-build` step.

This matches the user request. Tests ran successfully.

---
*PR created automatically by Jules for task [9318286151581262715](https://jules.google.com/task/9318286151581262715) started by @arran4*