### PR TITLE
🔒 Fix command injection in git clone by adding -- before repoURL

### DIFF
--- a/skills/skill_fetch.go
+++ b/skills/skill_fetch.go
@@ -57,7 +57,7 @@ func fetchRemote(source string) (string, string, error) {
 		repoURL = "https://github.com/" + source
 	}
 
-	cmd := exec.Command("git", "clone", "--depth", "1", repoURL, tempDir)
+	cmd := exec.Command("git", "clone", "--depth", "1", "--", repoURL, tempDir)
 	if output, err := cmd.CombinedOutput(); err != nil {
 		_ = os.RemoveAll(tempDir)
 		return "", "", fmt.Errorf("failed to clone remote repository %s: %s", repoURL, string(output))


### PR DESCRIPTION
🎯 **What:** This PR fixes a command/argument injection vulnerability in the `fetchRemote` function where a user-provided repository URL was being passed directly to `git clone` without proper argument separation.

⚠️ **Risk:** If an attacker provided a crafted source URL (e.g., starting with a dash like `--upload-pack=malicious-command`), it could be interpreted by the `git` CLI as an option rather than a positional argument (repository URL). This could lead to arbitrary command execution on the host machine running the `fetchRemote` function.

🛡️ **Solution:** The fix adds `--` before the `repoURL` parameter in the `exec.Command` call. This is a standard convention in Unix-like systems and POSIX-compliant CLI tools to signify the end of command options. It guarantees that the `git` command will treat the `repoURL` and the subsequent `tempDir` as positional arguments (the repository to clone and the destination directory) rather than as flags, thus mitigating the argument injection risk while preserving all legitimate cloning functionality.

---
*PR created automatically by Jules for task [10575777065461730755](https://jules.google.com/task/10575777065461730755) started by @arran4*