### PR TITLE
🧪 Add tests for SkillList

### DIFF
--- a/skills/skill_test.go
+++ b/skills/skill_test.go
@@ -230,10 +230,10 @@ func TestSkillList(t *testing.T) {
 
 	err := SkillList("project", "")
 
-	w.Close()
+	_ = w.Close()
 	os.Stdout = oldStdout
 	outBytes, _ := io.ReadAll(r)
-	r.Close()
+	_ = r.Close()
 	outStr := string(outBytes)
 
 	if err != nil {
@@ -254,10 +254,10 @@ func TestSkillList(t *testing.T) {
 	go func() {
 		_, _ = io.ReadAll(rInst)
 	}()
-	defer rInst.Close()
+	defer func() { _ = rInst.Close() }()
 	os.Stdout = wInst
 	err = SkillInstall(tempSource, "test_skill", "project", "")
-	wInst.Close()
+	_ = wInst.Close()
 	os.Stdout = oldStdoutInstall
 
 	if err != nil {
@@ -269,10 +269,10 @@ func TestSkillList(t *testing.T) {
 
 	err = SkillList("project", "")
 
-	w2.Close()
+	_ = w2.Close()
 	os.Stdout = oldStdout
 	outBytes2, _ := io.ReadAll(r2)
-	r2.Close()
+	_ = r2.Close()
 	outStr2 := string(outBytes2)
 
 	if err != nil {
@@ -288,17 +288,17 @@ func TestSkillList(t *testing.T) {
 	// 3. Test list when directory exists but metadata is missing
 	// Remove metadata file
 	metaPath := filepath.Join(tempDest, ".agents", "skills", "test_skill", "skill_metadata.json")
-	os.Remove(metaPath)
+	_ = os.Remove(metaPath)
 
 	r3, w3, _ := os.Pipe()
 	os.Stdout = w3
 
 	err = SkillList("project", "")
 
-	w3.Close()
+	_ = w3.Close()
 	os.Stdout = oldStdout
 	outBytes3, _ := io.ReadAll(r3)
-	r3.Close()
+	_ = r3.Close()
 	outStr3 := string(outBytes3)
 
 	if err != nil {

--- a/skills/skill_test.go
+++ b/skills/skill_test.go
@@ -1,8 +1,10 @@
 package skills
 
 import (
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -212,5 +214,97 @@ func TestSkillRemove(t *testing.T) {
 
 	if _, err := os.Stat(expectedPath); !os.IsNotExist(err) {
 		t.Fatalf("Skill directory was not removed.")
+	}
+}
+
+func TestSkillList(t *testing.T) {
+	tempDest := t.TempDir()
+	originalWd, _ := os.Getwd()
+	_ = os.Chdir(tempDest)
+	defer func() { _ = os.Chdir(originalWd) }()
+
+	// 1. Empty list
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := SkillList("project", "")
+
+	w.Close()
+	os.Stdout = oldStdout
+	outBytes, _ := io.ReadAll(r)
+	r.Close()
+	outStr := string(outBytes)
+
+	if err != nil {
+		t.Fatalf("SkillList empty failed: %v", err)
+	}
+	if !strings.Contains(outStr, "No skills installed.") {
+		t.Errorf("Expected 'No skills installed.' but got: %s", outStr)
+	}
+
+	// 2. Install a skill and test again
+	tempSource := t.TempDir()
+	skillMd := filepath.Join(tempSource, "SKILL.md")
+	_ = os.WriteFile(skillMd, []byte("# Test Skill"), 0644)
+
+	// Suppress output of SkillInstall
+	oldStdoutInstall := os.Stdout
+	rInst, wInst, _ := os.Pipe()
+	go func() {
+		_, _ = io.ReadAll(rInst)
+	}()
+	defer rInst.Close()
+	os.Stdout = wInst
+	err = SkillInstall(tempSource, "test_skill", "project", "")
+	wInst.Close()
+	os.Stdout = oldStdoutInstall
+
+	if err != nil {
+		t.Fatalf("SkillInstall failed: %v", err)
+	}
+
+	r2, w2, _ := os.Pipe()
+	os.Stdout = w2
+
+	err = SkillList("project", "")
+
+	w2.Close()
+	os.Stdout = oldStdout
+	outBytes2, _ := io.ReadAll(r2)
+	r2.Close()
+	outStr2 := string(outBytes2)
+
+	if err != nil {
+		t.Fatalf("SkillList with skills failed: %v", err)
+	}
+	if !strings.Contains(outStr2, "test_skill") {
+		t.Errorf("Expected 'test_skill' in output but got: %s", outStr2)
+	}
+	if !strings.Contains(outStr2, "project") {
+		t.Errorf("Expected 'project' in output but got: %s", outStr2)
+	}
+
+	// 3. Test list when directory exists but metadata is missing
+	// Remove metadata file
+	metaPath := filepath.Join(tempDest, ".agents", "skills", "test_skill", "skill_metadata.json")
+	os.Remove(metaPath)
+
+	r3, w3, _ := os.Pipe()
+	os.Stdout = w3
+
+	err = SkillList("project", "")
+
+	w3.Close()
+	os.Stdout = oldStdout
+	outBytes3, _ := io.ReadAll(r3)
+	r3.Close()
+	outStr3 := string(outBytes3)
+
+	if err != nil {
+		t.Fatalf("SkillList with missing metadata failed: %v", err)
+	}
+	if !strings.Contains(outStr3, "(no metadata)") {
+		t.Errorf("Expected '(no metadata)' in output but got: %s", outStr3)
 	}
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of unit tests for the `SkillList` function, which handles printing the installed AI agent skills.
📊 **Coverage:** The scenarios now tested include:
1. When no skills are installed (verifies empty message).
2. When a skill is installed correctly (verifies tabular output).
3. When a skill directory exists but the metadata file is missing (verifies graceful fallback).
✨ **Result:** The codebase has better test coverage for skill listing functionality, ensuring output correctly matches expectations and avoiding regressions.

---
*PR created automatically by Jules for task [12126209286164353504](https://jules.google.com/task/12126209286164353504) started by @arran4*