### PR TITLE
🧪 Add tests for Format in format.go

### DIFF
--- a/format_test.go
+++ b/format_test.go
@@ -1,0 +1,100 @@
+package go_subcommand
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestFormat(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "format_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	if err := os.WriteFile(filepath.Join(tempDir, "go.mod"), []byte("module github.com/test/mod\n\ngo 1.22"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	src := `package main
+
+// MyCmd is a subcommand ` + "`" + `test mycmd` + "`" + `
+func MyCmd(verbose bool, paths []string) {}
+`
+	filename := filepath.Join(tempDir, "main.go")
+	if err := os.WriteFile(filename, []byte(src), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cwd, _ := os.Getwd()
+	os.Chdir(tempDir)
+	defer os.Chdir(cwd)
+
+	err = Format(".", true, nil, true)
+	if err != nil {
+		t.Fatalf("Format failed: %v", err)
+	}
+
+	content, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	contentStr := string(content)
+	if !strings.Contains(contentStr, "// Flags:") {
+		t.Errorf("Expected Flags section in formatted comment, got:\n%s", contentStr)
+	}
+	if !strings.Contains(contentStr, "verbose") {
+		t.Errorf("Expected verbose param in formatted comment, got:\n%s", contentStr)
+	}
+}
+
+func TestFormat_NotInPlace(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "format_test_not_inplace")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	if err := os.WriteFile(filepath.Join(tempDir, "go.mod"), []byte("module github.com/test/mod\n\ngo 1.22"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	src := `package main
+
+// MyCmd is a subcommand ` + "`" + `test mycmd` + "`" + `
+func MyCmd(verbose bool) {}
+`
+	filename := filepath.Join(tempDir, "main.go")
+	if err := os.WriteFile(filename, []byte(src), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cwd, _ := os.Getwd()
+	os.Chdir(tempDir)
+	defer os.Chdir(cwd)
+
+	err = Format(".", false, nil, true)
+	if err != nil {
+		t.Fatalf("Format failed: %v", err)
+	}
+
+	content, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	contentStr := string(content)
+	if strings.Contains(contentStr, "// Flags:") {
+		t.Errorf("Expected Flags section to NOT be added when inplace=false, got:\n%s", contentStr)
+	}
+}
+
+func TestFormat_InvalidParse(t *testing.T) {
+	err := Format("non_existent_dir", true, nil, true)
+	if err == nil {
+		t.Errorf("Expected Format to fail with non-existent directory")
+	}
+}

--- a/format_test.go
+++ b/format_test.go
@@ -12,7 +12,7 @@ func TestFormat(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(tempDir)
+	defer func() { _ = os.RemoveAll(tempDir) }()
 
 	if err := os.WriteFile(filepath.Join(tempDir, "go.mod"), []byte("module github.com/test/mod\n\ngo 1.22"), 0644); err != nil {
 		t.Fatal(err)
@@ -29,8 +29,10 @@ func MyCmd(verbose bool, paths []string) {}
 	}
 
 	cwd, _ := os.Getwd()
-	os.Chdir(tempDir)
-	defer os.Chdir(cwd)
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(cwd) }()
 
 	err = Format(".", true, nil, true)
 	if err != nil {
@@ -56,7 +58,7 @@ func TestFormat_NotInPlace(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(tempDir)
+	defer func() { _ = os.RemoveAll(tempDir) }()
 
 	if err := os.WriteFile(filepath.Join(tempDir, "go.mod"), []byte("module github.com/test/mod\n\ngo 1.22"), 0644); err != nil {
 		t.Fatal(err)
@@ -73,8 +75,10 @@ func MyCmd(verbose bool) {}
 	}
 
 	cwd, _ := os.Getwd()
-	os.Chdir(tempDir)
-	defer os.Chdir(cwd)
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(cwd) }()
 
 	err = Format(".", false, nil, true)
 	if err != nil {


### PR DESCRIPTION
🎯 **What:** This PR introduces tests for the `Format` function in `format.go`, which previously lacked coverage.
📊 **Coverage:** The new tests cover:
- Happy path formatting in-place where it correctly identifies subcommands and rewrites doc comments with flag information.
- A scenario where `inplace` is set to false, asserting that the target file is not modified.
- Error handling behavior when `Format` is called on a non-existent directory.
✨ **Result:** Increased confidence and reliability of the `Format` function by ensuring its code modification capabilities are thoroughly tested under different flag configurations and edge cases.

---
*PR created automatically by Jules for task [386598047987092583](https://jules.google.com/task/386598047987092583) started by @arran4*