### PR TITLE
🧪 Add error condition tests for SkillRemove

### DIFF
--- a/skills/skill_test.go
+++ b/skills/skill_test.go
@@ -214,3 +214,30 @@ func TestSkillRemove(t *testing.T) {
 		t.Fatalf("Skill directory was not removed.")
 	}
 }
+
+func TestSkillRemove_Errors(t *testing.T) {
+	tempDest := t.TempDir()
+	originalWd, _ := os.Getwd()
+	_ = os.Chdir(tempDest)
+	defer func() { _ = os.Chdir(originalWd) }()
+
+	// Empty name
+	if err := SkillRemove("", "project", ""); err == nil {
+		t.Error("SkillRemove accepted an empty skill name")
+	}
+
+	// Invalid scope
+	if err := SkillRemove("skill", "invalid", ""); err == nil {
+		t.Error("SkillRemove accepted an invalid scope")
+	}
+
+	// Path traversal
+	if err := SkillRemove("../malicious", "project", ""); err == nil {
+		t.Error("SkillRemove accepted a path traversal attempt")
+	}
+
+	// Skill not installed
+	if err := SkillRemove("missing_skill", "project", ""); err == nil {
+		t.Error("SkillRemove accepted a missing skill")
+	}
+}


### PR DESCRIPTION
🎯 **What:** Added tests for the `SkillRemove` function to cover its error conditions, which were previously untested. The existing `TestSkillRemove` only covered the happy path.
📊 **Coverage:** The new `TestSkillRemove_Errors` test function covers scenarios including an empty skill name, an invalid scope, path traversal attempts, and attempts to remove a non-existent skill.
✨ **Result:** Test coverage for `SkillRemove` is now comprehensive, improving the reliability and maintainability of the codebase.

---
*PR created automatically by Jules for task [6055711769093782844](https://jules.google.com/task/6055711769093782844) started by @arran4*