### PR TITLE
🧪 Add tests for Scan subcommand functionality

### DIFF
--- a/scan_test.go
+++ b/scan_test.go
@@ -1,0 +1,71 @@
+package go_subcommand
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestScan(t *testing.T) {
+	dir := t.TempDir()
+
+	modGo := `module example.com/test
+
+go 1.22
+`
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(modGo), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	mainGo := `package main
+// Root is a subcommand ` + "`app`" + ` -- Some root description
+func Root() {}
+
+// Sub is a subcommand ` + "`app sub`" + ` -- Some description
+//
+// Flags:
+//
+//	flag1:	--flag1	(default: "val")	Some flag
+func Sub(flag1 string) {}
+`
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte(mainGo), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := Scan(dir, "commentv1", nil, true)
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	output := buf.String()
+
+	if err != nil {
+		t.Errorf("Scan failed: %v", err)
+	}
+
+	if !strings.Contains(output, "Command: app") {
+		t.Errorf("Expected output to contain 'Command: app', got: %s", output)
+	}
+	if !strings.Contains(output, "Subcommand: sub") {
+		t.Errorf("Expected output to contain 'Subcommand: sub', got: %s", output)
+	}
+	if !strings.Contains(output, "--flag1") {
+		t.Errorf("Expected output to contain '--flag1', got: %s", output)
+	}
+}
+
+func TestScan_Error(t *testing.T) {
+	err := Scan(".", "unknown_parser", nil, false)
+	if err == nil {
+		t.Errorf("Expected error with unknown parser, got nil")
+	}
+}

--- a/scan_test.go
+++ b/scan_test.go
@@ -2,64 +2,127 @@ package go_subcommand
 
 import (
 	"bytes"
+	"embed"
+	"encoding/json"
 	"io"
+	"io/fs"
 	"os"
-	"path/filepath"
+	"path"
+	"sort"
 	"strings"
 	"testing"
+	"testing/fstest"
+
+	"golang.org/x/tools/txtar"
 )
 
+func splitInputExpected(ar *txtar.Archive) (input, expected fstest.MapFS) {
+	input = fstest.MapFS{}
+	expected = fstest.MapFS{}
+
+	for _, f := range ar.Files {
+		switch {
+		case strings.HasPrefix(f.Name, "input/"):
+			input[strings.TrimPrefix(f.Name, "input/")] = &fstest.MapFile{Data: f.Data}
+		case strings.HasPrefix(f.Name, "expected/"):
+			expected[strings.TrimPrefix(f.Name, "expected/")] = &fstest.MapFile{Data: f.Data}
+		}
+	}
+	return input, expected
+}
+
+//go:embed testdata/scan/*.txtar
+var scanCases embed.FS
+
 func TestScan(t *testing.T) {
-	dir := t.TempDir()
-
-	modGo := `module example.com/test
-
-go 1.22
-`
-	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(modGo), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	mainGo := `package main
-// Root is a subcommand ` + "`app`" + ` -- Some root description
-func Root() {}
-
-// Sub is a subcommand ` + "`app sub`" + ` -- Some description
-//
-// Flags:
-//
-//	flag1:	--flag1	(default: "val")	Some flag
-func Sub(flag1 string) {}
-`
-	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte(mainGo), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	oldStdout := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	err := Scan(dir, "commentv1", nil, true)
-
-	_ = w.Close()
-	os.Stdout = oldStdout
-
-	var buf bytes.Buffer
-	_, _ = io.Copy(&buf, r)
-	output := buf.String()
-
+	var cases []string
+	err := fs.WalkDir(scanCases, "testdata/scan", func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(p, ".txtar") {
+			return nil
+		}
+		cases = append(cases, p)
+		return nil
+	})
 	if err != nil {
-		t.Errorf("Scan failed: %v", err)
+		t.Fatalf("failed to walk testdata: %v", err)
 	}
+	sort.Strings(cases)
 
-	if !strings.Contains(output, "Command: app") {
-		t.Errorf("Expected output to contain 'Command: app', got: %s", output)
-	}
-	if !strings.Contains(output, "Subcommand: sub") {
-		t.Errorf("Expected output to contain 'Subcommand: sub', got: %s", output)
-	}
-	if !strings.Contains(output, "--flag1") {
-		t.Errorf("Expected output to contain '--flag1', got: %s", output)
+	for _, tc := range cases {
+		tc := tc
+		t.Run(strings.TrimSuffix(path.Base(tc), ".txtar"), func(t *testing.T) {
+			raw, err := scanCases.ReadFile(tc)
+			if err != nil {
+				t.Fatalf("failed to read testcase %s: %v", tc, err)
+			}
+			ar := txtar.Parse(raw)
+			inputFS, expectedFS := splitInputExpected(ar)
+
+			dir := t.TempDir()
+			for name, file := range inputFS {
+				err := os.MkdirAll(path.Join(dir, path.Dir(name)), 0755)
+				if err != nil {
+					t.Fatalf("failed to mkdir for %s: %v", name, err)
+				}
+				err = os.WriteFile(path.Join(dir, name), file.Data, 0644)
+				if err != nil {
+					t.Fatalf("failed to write %s: %v", name, err)
+				}
+			}
+
+			// Read options if provided
+			var options struct {
+				Dir        string   `json:"dir"`
+				ParserName string   `json:"parser_name"`
+				Paths      []string `json:"paths"`
+				Recursive  bool     `json:"recursive"`
+			}
+			for _, f := range ar.Files {
+				if f.Name == "options.json" {
+					if err := json.Unmarshal(f.Data, &options); err != nil {
+						t.Fatalf("failed to parse options.json: %v", err)
+					}
+					break
+				}
+			}
+
+			oldStdout := os.Stdout
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+
+			if options.Dir == "" {
+				options.Dir = dir
+			} else {
+				options.Dir = path.Join(dir, options.Dir)
+			}
+			if options.ParserName == "" {
+				options.ParserName = "commentv1"
+			}
+
+			err = Scan(options.Dir, options.ParserName, options.Paths, options.Recursive)
+
+			_ = w.Close()
+			os.Stdout = oldStdout
+
+			var buf bytes.Buffer
+			_, _ = io.Copy(&buf, r)
+			output := buf.String()
+
+			if err != nil {
+				t.Fatalf("Scan failed: %v", err)
+			}
+
+			expectedOut, ok := expectedFS["output.txt"]
+			if ok {
+				expectedStr := string(expectedOut.Data)
+				if strings.TrimSpace(output) != strings.TrimSpace(expectedStr) {
+					t.Errorf("Expected output:\n%s\nGot:\n%s", expectedStr, output)
+				}
+			}
+		})
 	}
 }
 

--- a/scan_test.go
+++ b/scan_test.go
@@ -41,11 +41,11 @@ func Sub(flag1 string) {}
 
 	err := Scan(dir, "commentv1", nil, true)
 
-	w.Close()
+	_ = w.Close()
 	os.Stdout = oldStdout
 
 	var buf bytes.Buffer
-	io.Copy(&buf, r)
+	_, _ = io.Copy(&buf, r)
 	output := buf.String()
 
 	if err != nil {

--- a/testdata/scan/basic.txtar
+++ b/testdata/scan/basic.txtar
@@ -1,0 +1,28 @@
+test: basic scan scenario
+
+-- options.json --
+{
+	"dir": ".",
+	"parser_name": "commentv1",
+	"recursive": true
+}
+
+-- input/go.mod --
+module example.com/test
+go 1.22
+-- input/main.go --
+package main
+// Root is a subcommand `app` -- Some root description
+func Root() {}
+
+// Sub is a subcommand `app sub` -- Some description
+//
+// Flags:
+//
+//	flag1:	--flag1	(default: "val")	Some flag
+func Sub(flag1 string) {}
+-- expected/output.txt --
+Command: app
+  Subcommand: sub
+    Flags:
+      --flag1 string (default: "val") Some flag


### PR DESCRIPTION
🎯 **What:** The `Scan` function and its helper `printSubCommands` lacked test coverage. 
📊 **Coverage:** A new `scan_test.go` file covers the successful parsing and recursive command listing using standard out capturing, and an error case for missing parsers. 
✨ **Result:** Enhanced test coverage that reliably verifies standard subcommand scanning functionality.

---
*PR created automatically by Jules for task [16441864437836734553](https://jules.google.com/task/16441864437836734553) started by @arran4*