### PR TITLE
fix: correctly handle trailing spaces in formatted comments

### DIFF
--- a/format_comments.go
+++ b/format_comments.go
@@ -274,10 +274,8 @@ func FormatSourceComments(dir string, paths []string, recursive bool) error {
 						Text:  "// " + nl,
 						Slash: pos,
 					}
-					// Fix empty lines to be just "//"
-					if strings.TrimSpace(nl) == "" {
-						c.Text = "//"
-					}
+					// Fix empty lines and trailing spaces
+					c.Text = strings.TrimRight(c.Text, " 	")
 					newComments = append(newComments, c)
 				}
 


### PR DESCRIPTION
This PR modifies `format_comments.go` to properly handle empty lines and trailing spaces when formatting subcommand comments. 
Previously, the logic only specifically matched lines where `strings.TrimSpace(nl) == ""` to convert the comment body into `"//"`. This PR updates the logic to simply strip trailing whitespace with `c.Text = strings.TrimRight(c.Text, " \t")`, providing a cleaner handling for both empty comment lines (avoiding `"// "`) and any lines that naturally contain trailing whitespace.

The change has been validated by running the existing test suite via `go test ./...`.

---
*PR created automatically by Jules for task [5974745748797958989](https://jules.google.com/task/5974745748797958989) started by @arran4*