### PR TITLE
🧪 Add test for HelpSyntax

### DIFF
--- a/help_syntax_test.go
+++ b/help_syntax_test.go
@@ -29,7 +29,7 @@ func TestHelpSyntax(t *testing.T) {
 	}
 
 	// Close the writer so the reader knows it's done
-	w.Close()
+	_ = w.Close()
 
 	// Read the output
 	var buf bytes.Buffer

--- a/help_syntax_test.go
+++ b/help_syntax_test.go
@@ -1,0 +1,62 @@
+package go_subcommand
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestHelpSyntax(t *testing.T) {
+	// Save original stdout
+	oldStdout := os.Stdout
+	defer func() { os.Stdout = oldStdout }()
+
+	// Create a pipe
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("Failed to create pipe: %v", err)
+	}
+
+	// Set stdout to our writer
+	os.Stdout = w
+
+	// Run the function
+	err = HelpSyntax()
+	if err != nil {
+		t.Errorf("HelpSyntax() returned an error: %v", err)
+	}
+
+	// Close the writer so the reader knows it's done
+	w.Close()
+
+	// Read the output
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, r)
+	if err != nil {
+		t.Fatalf("Failed to copy from pipe: %v", err)
+	}
+
+	// Restore stdout early
+	os.Stdout = oldStdout
+
+	output := buf.String()
+
+	// Verify output
+	expectedPhrases := []string{
+		"Gosubc Syntax Guide",
+		"Command Definition:",
+		"Arguments / Flags:",
+		"Positional Arguments:",
+		"Variadic Arguments:",
+		"Defaults:",
+		"Implicit Parsing:",
+	}
+
+	for _, phrase := range expectedPhrases {
+		if !strings.Contains(output, phrase) {
+			t.Errorf("Expected output to contain %q, but it didn't", phrase)
+		}
+	}
+}

--- a/issues_test.go
+++ b/issues_test.go
@@ -279,6 +279,7 @@ func TestIssue20_NestedSubcommandsFlattened_Model(t *testing.T) {
 	}
 	if admin == nil {
 		t.Fatal("Expected 'admin' subcommand, but it was flattened or missing")
+		return
 	}
 
 	found := false

--- a/parsers/commentv1/parser_regr_test.go
+++ b/parsers/commentv1/parser_regr_test.go
@@ -86,6 +86,7 @@ func TestParserRegression(t *testing.T) {
 
 			if funcDecl == nil {
 				t.Fatalf("No function with doc comment found in input.go")
+				return
 			}
 
 			// 3. Extract params using the parser

--- a/parsers/commentv1/parser_test.go
+++ b/parsers/commentv1/parser_test.go
@@ -159,6 +159,7 @@ func ParseLocal(value string) (string, error) { return value, nil }
 	localParser := child.Parameters[1].Parser.Func
 	if localParser == nil {
 		t.Fatal("local parser was not recorded")
+		return
 	}
 	if localParser.ImportPath != "example.com/project/internal" || localParser.CommandPackageName != "app" || localParser.FunctionName != "ParseLocal" {
 		t.Errorf("local parser reference = %#v", localParser)


### PR DESCRIPTION
🎯 **What:** Added a missing unit test for the HelpSyntax function in `help_syntax.go`.
📊 **Coverage:** Validated the `HelpSyntax()` output string to ensure it contains the expected syntax guide text by capturing `os.Stdout`. Also verifies that no errors are returned.
✨ **Result:** Improves test coverage for the tool's built-in help commands.

---
*PR created automatically by Jules for task [8792616637790837118](https://jules.google.com/task/8792616637790837118) started by @arran4*