### PR TITLE
🧹 [code health improvement] Refactor string parsing for ToKebabCase

### DIFF
--- a/parsers/sanitize.go
+++ b/parsers/sanitize.go
@@ -15,7 +15,10 @@ func ToKebabCase(s string) string {
 	if err != nil {
 		return s
 	}
-	res, _ := strings2.ToKebabCase(words, strings2.OptionCaseMode(strings2.CMWhispering))
+	res, err := strings2.ToKebabCase(words, strings2.OptionCaseMode(strings2.CMWhispering))
+	if err != nil {
+		return s
+	}
 	return res
 }
 
@@ -52,7 +55,6 @@ func SanitizeToIdentifier(name string) string {
 
 	return res
 }
-
 
 // NameAllocator manages the assignment of unique identifier names.
 type NameAllocator struct {


### PR DESCRIPTION
🎯 **What:** Handled the error returned by strings2.ToKebabCase instead of explicitly ignoring it with the blank identifier.
💡 **Why:** To improve code health, maintainability, and safety by ensuring that if string formatting fails, the function safely falls back to returning the original string instead of a potentially malformed or empty string.
✅ **Verification:** Verified by running the entire test suite (go test ./...) which passed.
✨ **Result:** Improved error handling and removed a silent failure point.

---
*PR created automatically by Jules for task [8704275917426461591](https://jules.google.com/task/8704275917426461591) started by @arran4*