### PR TITLE
🧹 Remove dummy skill resolution hack

### DIFF
--- a/skills/skill_agent.go
+++ b/skills/skill_agent.go
@@ -10,6 +10,15 @@ import (
 // If scope is "project", it installs in the current working directory's .agents/skills/.
 // If scope is "user", it installs in the user's home directory under .agents/skills/ (or an agent-specific path).
 func resolveSkillPath(agentName, scope, skillName string) (string, error) {
+	root, err := resolveSkillRoot(agentName, scope)
+	if err != nil {
+		return "", err
+	}
+	return validateSafePath(root, filepath.Join(root, skillName))
+}
+
+// resolveSkillRoot returns the root directory for all skills for a given agent and scope.
+func resolveSkillRoot(agentName, scope string) (string, error) {
 	var baseDir string
 
 	switch scope {
@@ -39,16 +48,5 @@ func resolveSkillPath(agentName, scope, skillName string) (string, error) {
 		return "", fmt.Errorf("invalid scope: %s (must be 'user' or 'project')", scope)
 	}
 
-	root := filepath.Join(baseDir, "skills")
-	return validateSafePath(root, filepath.Join(root, skillName))
-}
-
-// resolveSkillRoot returns the root directory for all skills for a given agent and scope.
-func resolveSkillRoot(agentName, scope string) (string, error) {
-	// A small hack: resolve for a dummy name, then take the parent dir
-	dummyPath, err := resolveSkillPath(agentName, scope, "dummy")
-	if err != nil {
-		return "", err
-	}
-	return filepath.Dir(dummyPath), nil
+	return filepath.Join(baseDir, "skills"), nil
 }


### PR DESCRIPTION
🎯 **What:** The code health issue addressed is the removal of a "dummy" skill resolution hack in `resolveSkillRoot`. The path generation logic previously embedded in `resolveSkillPath` has been properly extracted to `resolveSkillRoot`. `resolveSkillPath` now calls `resolveSkillRoot` to get the base path instead.

💡 **Why:** This improves maintainability by directly computing the parent directory in `resolveSkillRoot` rather than calling `resolveSkillPath` with a "dummy" filename just to extract its parent. It cleans up the code and avoids unnecessary logic jumps.

✅ **Verification:** The changes were verified by running `go test ./...` which runs the full test suite. The existing tests in `skills/skill_test.go` still pass properly, confirming that this change does not introduce regressions and safely maintains existing functionality.

✨ **Result:** The codebase is cleaner and the path resolution logic is simpler and more readable.

---
*PR created automatically by Jules for task [11691952257335488981](https://jules.google.com/task/11691952257335488981) started by @arran4*