### PR TITLE
🧹 [code health improvement] Use go:embed for testdata in format_comments_test.go

### DIFF
--- a/format_comments_test.go
+++ b/format_comments_test.go
@@ -1,6 +1,7 @@
 package go_subcommand
 
 import (
+	_ "embed"
 	"go/ast"
 	goparser "go/parser"
 	"go/token"
@@ -12,11 +13,11 @@ import (
 	"golang.org/x/tools/txtar"
 )
 
+//go:embed testdata/format_regr.txtar
+var formatRegrData []byte
+
 func TestFormatSourceComments(t *testing.T) {
-	archive, err := txtar.ParseFile("testdata/format_regr.txtar")
-	if err != nil {
-		t.Fatal(err)
-	}
+	archive := txtar.Parse(formatRegrData)
 
 	tempDir, err := os.MkdirTemp("", "format_test")
 	if err != nil {


### PR DESCRIPTION
🎯 What: Modified `format_comments_test.go` to use `go:embed` for reading `testdata/format_regr.txtar` directly from memory, instead of using `txtar.ParseFile` which requires disk reading.
💡 Why: Tests that depend on local disk reads are brittle and can lead to environment-specific failures. Using `go:embed` makes the test faster, more hermetic, and independent of runtime file paths.
✅ Verification: `go test ./...` continues to pass, ensuring the change introduces no functional regressions.
✨ Result: The test suite is slightly faster and more resilient, successfully loading the necessary txtar mock structure without touching the filesystem.

---
*PR created automatically by Jules for task [5996326741959676679](https://jules.google.com/task/5996326741959676679) started by @arran4*