### PR TITLE
feat: format `os.Getenv` in default values as shell env vars

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -25,6 +25,28 @@ var ReservedKeywords = []string{
 	"strconv", "time", "flag", "fmt", "os", "strings", "slices",
 }
 
+// DefaultExpressionFormatters is a registry of formatters for default expressions.
+// It allows extending how specific expressions (like os.Getenv) are formatted in usage output.
+var DefaultExpressionFormatters = []func(ast.Expr) (string, bool){
+	formatGetenv,
+}
+
+func formatGetenv(expr ast.Expr) (string, bool) {
+	if callExpr, ok := expr.(*ast.CallExpr); ok {
+		if sel, ok := callExpr.Fun.(*ast.SelectorExpr); ok {
+			if id, ok := sel.X.(*ast.Ident); ok {
+				if id.Name == "os" && sel.Sel.Name == "Getenv" && len(callExpr.Args) == 1 {
+					if lit, ok := callExpr.Args[0].(*ast.BasicLit); ok {
+						envName := strings.Trim(lit.Value, "\"")
+						return "$" + envName, true
+					}
+				}
+			}
+		}
+	}
+	return "", false
+}
+
 // DataModel represents the parsed data model of the Go files, containing commands and package information.
 type DataModel struct {
 	// FileSet is the token.FileSet used for parsing.
@@ -291,16 +313,10 @@ func (p *FunctionParameter) DefaultString() string {
 	def := p.Default
 
 	if expr, err := parser.ParseExpr(def); err == nil {
-		if callExpr, ok := expr.(*ast.CallExpr); ok {
-			if sel, ok := callExpr.Fun.(*ast.SelectorExpr); ok {
-				if id, ok := sel.X.(*ast.Ident); ok {
-					if id.Name == "os" && sel.Sel.Name == "Getenv" && len(callExpr.Args) == 1 {
-						if lit, ok := callExpr.Args[0].(*ast.BasicLit); ok {
-							envName := strings.Trim(lit.Value, "\"")
-							def = "$" + envName
-						}
-					}
-				}
+		for _, formatter := range DefaultExpressionFormatters {
+			if formatted, ok := formatter(expr); ok {
+				def = formatted
+				break
 			}
 		}
 	}

--- a/model/model.go
+++ b/model/model.go
@@ -2,8 +2,11 @@ package model
 
 import (
 	"fmt"
+	"go/ast"
+	"go/parser"
 	"go/token"
 	"path"
+	"runtime"
 	"slices"
 	"sort"
 	"strings"
@@ -287,6 +290,26 @@ func (p *FunctionParameter) DefaultString() string {
 		return ""
 	}
 	def := p.Default
+
+	if expr, err := parser.ParseExpr(def); err == nil {
+		if callExpr, ok := expr.(*ast.CallExpr); ok {
+			if sel, ok := callExpr.Fun.(*ast.SelectorExpr); ok {
+				if id, ok := sel.X.(*ast.Ident); ok {
+					if id.Name == "os" && sel.Sel.Name == "Getenv" && len(callExpr.Args) == 1 {
+						if lit, ok := callExpr.Args[0].(*ast.BasicLit); ok {
+							envName := strings.Trim(lit.Value, "\"")
+							if runtime.GOOS == "windows" {
+								def = "%" + envName + "%"
+							} else {
+								def = "$" + envName
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
 	if p.Type == "string" && !strings.HasPrefix(def, "\"") {
 		def = fmt.Sprintf("%q", def)
 	}

--- a/model/model.go
+++ b/model/model.go
@@ -6,7 +6,6 @@ import (
 	"go/parser"
 	"go/token"
 	"path"
-	"runtime"
 	"slices"
 	"sort"
 	"strings"
@@ -298,11 +297,7 @@ func (p *FunctionParameter) DefaultString() string {
 					if id.Name == "os" && sel.Sel.Name == "Getenv" && len(callExpr.Args) == 1 {
 						if lit, ok := callExpr.Args[0].(*ast.BasicLit); ok {
 							envName := strings.Trim(lit.Value, "\"")
-							if runtime.GOOS == "windows" {
-								def = "%" + envName + "%"
-							} else {
-								def = "$" + envName
-							}
+							def = "$" + envName
 						}
 					}
 				}
@@ -310,7 +305,7 @@ func (p *FunctionParameter) DefaultString() string {
 		}
 	}
 
-	if p.Type == "string" && !strings.HasPrefix(def, "\"") {
+	if p.Type == "string" && !strings.HasPrefix(def, "\"") && !strings.HasPrefix(def, "$") {
 		def = fmt.Sprintf("%q", def)
 	}
 	if p.Type == "string" && def == "\"\"" && !p.HasDefaultValue {

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -187,3 +187,14 @@ func TestCommandAndSubCommandHelpers(t *testing.T) {
 		t.Error("expected flag and default widths for inherited parameters")
 	}
 }
+
+func TestDefaultStringGetenv(t *testing.T) {
+	p := &FunctionParameter{
+		Type:            "string",
+		Default:         "os.Getenv(\"PATH\")",
+		HasDefaultValue: true,
+	}
+	if got := p.DefaultString(); got != "(default: $PATH)" {
+		t.Errorf("DefaultString() = %q", got)
+	}
+}


### PR DESCRIPTION
Updates `DefaultString()` in `model.go` to safely parse and translate `os.Getenv` calls into their shell equivalents. Includes test golden updates.

---
*PR created automatically by Jules for task [8782766404490480532](https://jules.google.com/task/8782766404490480532) started by @arran4*