### PR TITLE
🧹 [Code Health] Change comment to prevent issue scanner false positive

### DIFF
--- a/format_comments.go
+++ b/format_comments.go
@@ -274,7 +274,7 @@ func FormatSourceComments(dir string, paths []string, recursive bool) error {
 						Text:  "// " + nl,
 						Slash: pos,
 					}
-					// Fix empty lines to be just "//"
+					// Ensure empty lines are just "//"
 					if strings.TrimSpace(nl) == "" {
 						c.Text = "//"
 					}


### PR DESCRIPTION
🎯 What:
Changed the comment `// Fix empty lines to be just "//"` to `// Ensure empty lines are just "//"`.

💡 Why:
The word "Fix" triggers issue scanners to flag it as a pending TODO, even though the comment is just explaining the code right beneath it that correctly handles empty lines. Replacing "Fix" with "Ensure" prevents this misinterpretation.

✅ Verification:
Ran tests via `go test ./...` which pass. The actual logic remains untouched and functions correctly as seen in prior runs.

✨ Result:
Cleaned up misleading comment which satisfies the issue reporter.

---
*PR created automatically by Jules for task [15667890348069379746](https://jules.google.com/task/15667890348069379746) started by @arran4*