### PR TITLE
🔒 Fix insecure path traversal vulnerability in sanitizeManFileName

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -461,18 +461,40 @@ func assignUsageFileNames(subCommands []*model.SubCommand) {
 }
 
 func sanitizeManFileName(mainCmdName, subCmdSequence string) string {
-	safeMain := filepath.Base(mainCmdName)
-	// subCmdSequence is space separated
+	safeMain := sanitizePathPart(mainCmdName)
+	if safeMain == "" {
+		safeMain = "unnamed"
+	}
+
 	parts := strings.Fields(subCmdSequence)
 	var safeParts []string
 	for _, p := range parts {
-		safeParts = append(safeParts, filepath.Base(p))
+		if safeP := sanitizePathPart(p); safeP != "" {
+			safeParts = append(safeParts, safeP)
+		}
 	}
+
 	safeSeq := strings.Join(safeParts, "-")
 	if safeSeq == "" {
 		return fmt.Sprintf("%s.1", safeMain)
 	}
 	return fmt.Sprintf("%s-%s.1", safeMain, safeSeq)
+}
+
+func sanitizePathPart(part string) string {
+	// Replace Windows separators first to normalize if on a non-Windows OS handling Windows paths
+	part = strings.ReplaceAll(part, "\\", "/")
+	// Use filepath.Rel to resolve path traversals securely against root
+	safe, err := filepath.Rel("/", filepath.Join("/", part))
+	if err != nil {
+		safe = part
+	}
+	// Extract just the filename to avoid creating subdirectories
+	safe = filepath.Base(safe)
+	if safe == "." || safe == "/" || safe == "\\" || safe == ".." {
+		return ""
+	}
+	return safe
 }
 
 func generateSubCommandFiles(writer FileWriter, cmdOutDir, cmdTemplatesDir, manDir string, subCmd *model.SubCommand) error {

--- a/generate_sanitize_test.go
+++ b/generate_sanitize_test.go
@@ -1,0 +1,59 @@
+package go_subcommand
+
+import (
+	"testing"
+)
+
+func TestSanitizePathPart(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"normal", "foo", "foo"},
+		{"path traversal", "../evil", "evil"},
+		{"deep traversal", "../../etc/passwd", "passwd"},
+		{"absolute", "/etc/passwd", "passwd"},
+		{"root", "/", ""},
+		{"empty", "", ""},
+		{"dot", ".", ""},
+		{"dotdot", "..", ""},
+		{"windows absolute", "C:\\Windows\\System32", "System32"},
+		{"complex", "foo/bar/baz", "baz"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := sanitizePathPart(tc.input)
+			if actual != tc.expected {
+				t.Errorf("sanitizePathPart(%q) = %q, expected %q", tc.input, actual, tc.expected)
+			}
+		})
+	}
+}
+
+func TestSanitizeManFileName(t *testing.T) {
+	tests := []struct {
+		name       string
+		mainCmd    string
+		subCmdSeq  string
+		expected   string
+	}{
+		{"normal", "mycmd", "sub1 sub2", "mycmd-sub1-sub2.1"},
+		{"traversal main", "../evil", "sub1", "evil-sub1.1"},
+		{"traversal sub", "mycmd", "../evil sub2", "mycmd-evil-sub2.1"},
+		{"all traversal", "../foo", "../bar ../baz", "foo-bar-baz.1"},
+		{"empty sub", "mycmd", "", "mycmd.1"},
+		{"slashes", "/bin/mycmd", "/sub1 /sub2", "mycmd-sub1-sub2.1"},
+		{"only root", "/", "/", "unnamed.1"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := sanitizeManFileName(tc.mainCmd, tc.subCmdSeq)
+			if actual != tc.expected {
+				t.Errorf("sanitizeManFileName(%q, %q) = %q, expected %q", tc.mainCmd, tc.subCmdSeq, actual, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
🎯 **What:**
The `sanitizeManFileName` function in `generate.go` previously relied solely on `filepath.Base()` to sanitize strings intended for generated manual filenames. `filepath.Base()` does not resolve path traversals correctly across all platforms and contexts, meaning inputs like `"../evil"` could escape intended directories when combined with `filepath.Join()`.

⚠️ **Risk:**
Path Traversal / Directory Escape. A malicious configuration or manipulated sequence input could write `.1` manual files to arbitrary locations on the file system, potentially overwriting critical files or placing unintended artifacts during the build process.

🛡️ **Solution:**
Replaced the reliance on `filepath.Base` for path part sanitization with a highly secure custom `sanitizePathPart` function. The new function safely resolves any directory traversals via `filepath.Rel("/", filepath.Join("/", part))` and then applies `filepath.Base()` to ensure only a pure, secure filename element is returned. Added comprehensive unit tests in `generate_sanitize_test.go` to explicitly prevent regressions related to path escaping across root, parent traversal dots (`..`), and mixed paths.

---
*PR created automatically by Jules for task [7036487516965206309](https://jules.google.com/task/7036487516965206309) started by @arran4*