### PR TITLE
docs: update README to clarify arbitrary command nesting depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,18 +247,22 @@ To enforce that a specific flag must be provided at runtime, mark the parameter 
 
 ### Nesting Commands
 
-Nesting is implicit based on the command path string.
+Nesting is implicit based on the command path string. You can nest commands arbitrarily deep (e.g., subcommands, sub-subcommands, etc.) simply by adding more words to the path.
 
 ```go
 // Root command: `app`
 // Child: `app users`
-// Grandchild: `app users create`
+// Grandchild (Sub-subcommand): `app users create`
+// Great-grandchild (Sub-sub-subcommand): `app users create admin`
 
 // CreateUser is a subcommand `app users create`
 func CreateUser(...) { ... }
 
 // ListUsers is a subcommand `app users list`
 func ListUsers(...) { ... }
+
+// CreateAdminUser is a subcommand `app users create admin`
+func CreateAdminUser(...) { ... }
 ```
 
 ### Parent Flags (Inheritance)


### PR DESCRIPTION
Updated the 'Nesting Commands' section in README.md to explicitly state that go-subcommands supports sub-sub commands and arbitrarily deep nesting by adding more words to the command path. Included an example of a sub-sub-subcommand (`app users create admin`).

---
*PR created automatically by Jules for task [18335806790239575256](https://jules.google.com/task/18335806790239575256) started by @arran4*