### PR TITLE
🔒 [security fix for template export file permissions]

### DIFF
--- a/template_cmd.go
+++ b/template_cmd.go
@@ -49,7 +49,7 @@ func exportDir(output string) error {
 			return err
 		}
 
-		return os.WriteFile(targetPath, content, 0644)
+		return os.WriteFile(targetPath, content, 0600)
 	})
 
 	if err != nil {
@@ -90,7 +90,7 @@ func exportTxtar(output string) error {
 	}
 
 	content := txtar.Format(archive)
-	if err := os.WriteFile(output, content, 0644); err != nil {
+	if err := os.WriteFile(output, content, 0600); err != nil {
 		return fmt.Errorf("failed to write txtar file %s: %w", output, err)
 	}
 


### PR DESCRIPTION
🎯 **What:** The `os.WriteFile` calls in `template_cmd.go` for exporting templates were creating files with `0644` permissions, which could potentially expose sensitive files to other users on the system if run in a shared environment.
⚠️ **Risk:** Files created with `0644` permissions are world-readable. If these templates contained any sensitive information or configurations, they would be accessible to any user on the system, which is an unnecessary risk for generated or exported files.
🛡️ **Solution:** Updated the file permissions in `os.WriteFile` from `0644` to `0600` on lines 52 and 93 of `template_cmd.go`. This restricts read and write access strictly to the owner of the file, following security best practices for generated or downloaded files.

---
*PR created automatically by Jules for task [10070746031572487728](https://jules.google.com/task/10070746031572487728) started by @arran4*